### PR TITLE
Adjusted GAC script so all files are loaded as config items

### DIFF
--- a/code/powershell/scan-options-gac.md
+++ b/code/powershell/scan-options-gac.md
@@ -1,0 +1,7 @@
+# Usage
+
+When setting the scan options, use the following values for the `PowerShell Queries` scan option:
+
+`Description`: `GAC`
+`Key Name`: `Name`
+`Query`: Script as provided in `scan-options-gac.ps1`

--- a/code/powershell/scan-options-gac.ps1
+++ b/code/powershell/scan-options-gac.ps1
@@ -1,9 +1,6 @@
 [regex]$regex   = '(?<Name>\S+), Version=(?<Version>\S+), Culture=(?<Culture>\S+), PublicKeyToken=(?<PublicKeyToken>\S+)'
 $folder         = "C:\Windows\Assembly"
-$gac            = "PublicKeyToken;   Version; Culture; Name; File Version`r`n"
-$gac            += "------------------------------------------------------------`r`n"
-[PSCustomObject[]]$collected      = @()
-$fileDict     = @{}
+$gac = @()
 
 foreach($f in Get-ChildItem -Path $folder -Recurse -Force -ErrorAction SilentlyContinue | where { ! $_.PSIsContainer })
 {
@@ -12,37 +9,21 @@ foreach($f in Get-ChildItem -Path $folder -Recurse -Force -ErrorAction SilentlyC
         $a      = [Reflection.Assembly]::LoadFile($f.FullName).FullName
         $fv    = [Diagnostics.FileVersionInfo]::GetVersionInfo($f.FullName).FileVersion
         $result = $a -match $regex
-                
+        $subfolder = $f.FullName.Split('\')[3]
+        $name = $subfolder + '-' + $matches.Name
+
         $tempObj = New-Object –TypeName PSObject
-        $tempObj | Add-Member -MemberType NoteProperty –Name Name –Value $matches.Name
+        $tempObj | Add-Member -MemberType NoteProperty –Name Name –Value $name
+        $tempObj | Add-Member -MemberType NoteProperty –Name Path –Value $f.FullName
         $tempObj | Add-Member -MemberType NoteProperty –Name Culture –Value $matches.Culture
         $tempObj | Add-Member -MemberType NoteProperty –Name Version –Value $matches.Version
         $tempObj | Add-Member -MemberType NoteProperty -Name PublicKeyToken -Value $matches.PublicKeyToken
         $tempObj | Add-Member -MemberType NoteProperty -Name FileVersion -Value $fv
-        
-        $subfolder = $f.FullName.Split('\')[3]
-        if($fileDict.ContainsKey($folder + "\" + $subfolder)) {
-            $fileDict[$folder + "\" + $subfolder] += $tempObj
-        } else {
-            $fileDict[$folder + "\" + $subfolder] = @($tempObj)
-        }
-                
+        $tempObj | Add-Member -MemberType NoteProperty -Name SubFolder -Value $subfolder
+
+        $gac += $tempObj
     } catch [System.Exception] {
         $err = "Could not read file " + $f + ": " + $_.Exception.Message
     }
 }
-
-foreach($g in $fileDict.GetEnumerator() | Sort-Object { $_.Key }) {
-
-    $collected = $fileDict[$g.Key] | Sort-Object Name
-    $gac += $g.Key
-    $gac += "`r`n"
-    foreach($line in $collected) {
-        $gac += "#" + $line.PublicKeyToken + "; " + $line.Version + "; " + $line.Culture + "; " + $line.Name + "; " + $line.FileVersion + "`r`n"
-    }
-}
-
-$output = "" | Select folder, raw
-$output.folder = $folder
-$output.raw    = $gac
-$output
+$gac


### PR DESCRIPTION
Previously, the GAC scan options loaded as a single file with each file in the GAC listed as a line:

![screen shot 2017-01-31 at 10 47 34 am](https://cloud.githubusercontent.com/assets/2061751/22472496/cfa4ccaa-e7a3-11e6-8506-325c44876ab7.png)

![screen shot 2017-01-31 at 10 55 54 am](https://cloud.githubusercontent.com/assets/2061751/22472515/e2c62d4c-e7a3-11e6-84f1-bc8411c57dcc.png)

This is not easy to build a policy from, so I've adjusted it so each file is loaded as a configuration item under the `GAC` section:

![screen shot 2017-01-31 at 10 45 42 am](https://cloud.githubusercontent.com/assets/2061751/22472526/ea64ca90-e7a3-11e6-972a-5063f93e4d75.png)

![screen shot 2017-01-31 at 10 45 52 am](https://cloud.githubusercontent.com/assets/2061751/22472548/f828094e-e7a3-11e6-82ae-c5bb080459a5.png)
