### PR TITLE
Pci audit win

### DIFF
--- a/policies/PCI_3_2_Audit_Check_Windows.json
+++ b/policies/PCI_3_2_Audit_Check_Windows.json
@@ -258,7 +258,7 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
                         "description": "17.5.2 (L1) Ensure 'Audit Group Membership' is set to 'Success'"
                     },
                     "description": "17.5.2 (L1) Ensure 'Audit Group Membership' is set to 'Success'",
@@ -305,21 +305,11 @@
                     "checks": {
                         "Logon": [
                             {
+                                "exp": "Success and Failure",
                                 "check": "equals",
                                 "expected": "Success and Failure",
-                                "valueSelectList": null,
-                                "attributeSelectList": null,
-                                "availableAttributes": null
-                            },
-                            {
-                                "name": "Logon",
-                                "path": [
-                                    "10.2.5 Use of and changes to identification and authentication mechanisms—including but not limited to creation of new accounts and elevation of privileges—and all changes, additions, or deletions to accounts with root or administrative privileges",
-                                    "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'"
-                                ],
-                                "check": "equals",
-                                "background": "This subcategory reports when a user attempts to log on to the system. These events occur on the accessed computer. For interactive logons, the generation of these events occurs on the computer that is logged on to. If a network logon takes place to access a share, these events generate on the computer that hosts the accessed resource. If you configure this setting to No auditing, it is difficult or impossible to determine which user has accessed or attempted to access organization computers. Events for this subcategory include:\n4624: An account was successfully logged on.\n4625: An account failed to log on.\n4648: A logon was attempted using explicit credentials.\n4675: SIDs were filtered.\nThe recommended state for this setting is: Success and Failure .",
-                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success and Failure :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff\\Audit Logon"
+                                "background": "This subcategory reports when a user attempts to log on to the system. These events occur on the accessed computer. For interactive logons, the generation of these events occurs on the computer that is logged on to. If a network logon takes place to access a share, these events generate on the computer that hosts the accessed resource. If you configure this setting to No auditing, it is difficult or impossible to determine which user has accessed or attempted to access organization computers. Events for this subcategory include:",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success and Failure : Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff\\Audit Logon"
                             }
                         ],
                         "present": [
@@ -459,19 +449,21 @@
                                 "expected": "true"
                             }
                         ],
-                        "Policy Change": {
-                            "check": "equals",
-                            "expected": "Success and Failure",
-                            "valueSelectList": null,
-                            "attributeSelectList": [
-                                "User Account Management"
-                            ],
-                            "availableAttributes": [
-                                {
-                                    "User Account Management": "Success"
-                                }
-                            ]
-                        }
+                        "Policy Change": [
+                            {
+                                "check": "equals",
+                                "expected": "Success and Failure",
+                                "valueSelectList": null,
+                                "attributeSelectList": [
+                                    "User Account Management"
+                                ],
+                                "availableAttributes": [
+                                    {
+                                        "User Account Management": "Success"
+                                    }
+                                ]
+                            }
+                        ]
                     },
                     "ci_path": [
                         "PowerShell",
@@ -605,6 +597,7 @@
         {
             "Policy Version": [
                 {
+                    "id": "Policy-Version-PCI-Server-Hardening-Policy-Version",
                     "name": "[PCI: Server-Hardening] Policy Version",
                     "error": false,
                     "checks": {
@@ -618,10 +611,11 @@
                     "ci_path": null,
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "echo \"20170925-1\";",
+                        "query": "echo \"20170926-0\";",
                         "description": "[PCI: Server-Hardening] Policy Version"
                     },
-                    "description": "[PCI: Server-Hardening] Policy Version"
+                    "description": "[PCI: Server-Hardening] Policy Version",
+                    "nodeGroupsOpen": true
                 }
             ]
         }
@@ -654,7 +648,7 @@
             },
             {
                 "description": "17.5.2 (L1) Ensure 'Audit Group Membership' is set to 'Success'",
-                "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
                 "description": "17.5.3 (L1) Ensure 'Audit Logoff' is set to 'Success'",
@@ -694,7 +688,7 @@
             },
             {
                 "description": "[PCI: Server-Hardening] Policy Version",
-                "query": "echo \"20170925-1\";"
+                "query": "echo \"20170926-0\";"
             }
         ]
     }

--- a/policies/PCI_3_2_Audit_Check_Windows.json
+++ b/policies/PCI_3_2_Audit_Check_Windows.json
@@ -16,7 +16,7 @@
         {
             "10.1 Implement audit trails to link all access to system components to each individual user.": [
                 {
-                    "id": "10-1-Implement-audit-trails-to-link-all-access-to-system-components-to-each-individual-user-17-3-1-Ensure-Audit-PNP-Activity-is-set-to-Success-",
+                    "id": "10-1-Implement-audit-trails-to-link-all-access-to-system-components-to-each-individual-user-PCI-Audit-Check-Ensure-Audit-PNP-Activity-is-set-to-Success-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit PNP Activity' is set to 'Success'",
                     "error": false,
                     "checks": {
@@ -55,7 +55,7 @@
                     "nodeGroupsOpen": true
                 },
                 {
-                    "id": "10-1-Implement-audit-trails-to-link-all-access-to-system-components-to-each-individual-user-17-3-2-Ensure-Audit-Process-Creation-is-set-to-Success-",
+                    "id": "10-1-Implement-audit-trails-to-link-all-access-to-system-components-to-each-individual-user-PCI-Audit-Check-Ensure-Audit-Process-Creation-is-set-to-Success-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Process Creation' is set to 'Success'",
                     "error": false,
                     "checks": {
@@ -93,7 +93,7 @@
         {
             "10.2.4 Verify invalid logical access attempts are logged.": [
                 {
-                    "id": "10-2-4-Verify-invalid-logical-access-attempts-are-logged-17-2-4-Ensure-Audit-Other-Account-Management-Events-is-set-to-Success-and-Failure-",
+                    "id": "10-2-4-Verify-invalid-logical-access-attempts-are-logged-PCI-Audit-Check-Ensure-Audit-Other-Account-Management-Events-is-set-to-Success-and-Failure-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
@@ -127,7 +127,7 @@
                     "nodeGroupsOpen": true
                 },
                 {
-                    "id": "10-2-4-Verify-invalid-logical-access-attempts-are-logged-17-5-1-Ensure-Audit-Account-Lockout-is-set-to-Success-and-Failure-",
+                    "id": "10-2-4-Verify-invalid-logical-access-attempts-are-logged-PCI-Audit-Check-Ensure-Audit-Account-Lockout-is-set-to-Success-and-Failure-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Account Lockout' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
@@ -166,7 +166,7 @@
         {
             "10.2.5 Use of and changes to identification and authentication mechanisms—including but not limited to creation of new accounts and elevation of privileges—and all changes, additions, or deletions to accounts with root or administrative privileges": [
                 {
-                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-2-2-Ensure-Audit-Computer-Account-Management-is-set-to-Success-and-Failure-",
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges-PCI-Audit-Check-Ensure-Audit-Computer-Account-Management-is-set-to-Success-and-Failure-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Computer Account Management' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
@@ -200,7 +200,7 @@
                     "nodeGroupsOpen": true
                 },
                 {
-                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-2-6-Ensure-Audit-User-Account-Management-is-set-to-Success-and-Failure-",
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges-PCI-Audit-Check-Ensure-Audit-User-Account-Management-is-set-to-Success-and-Failure-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit User Account Management' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
@@ -233,7 +233,7 @@
                     "nodeGroupsOpen": true
                 },
                 {
-                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-2-L1-Ensure-Audit-Group-Membership-is-set-to-Success-",
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges-PCI-Audit-Check-Ensure-Audit-Group-Membership-is-set-to-Success-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Group Membership' is set to 'Success'",
                     "error": false,
                     "checks": {
@@ -267,7 +267,7 @@
                     "nodeGroupsOpen": true
                 },
                 {
-                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-3-L1-Ensure-Audit-Logoff-is-set-to-Success-",
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges-PCI-Audit-Check-Ensure-Audit-Logoff-is-set-to-Success-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Logoff' is set to 'Success'",
                     "error": false,
                     "checks": {
@@ -303,7 +303,7 @@
                     "nodeGroupsOpen": true
                 },
                 {
-                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-4-L1-Ensure-Audit-Logon-is-set-to-Success-and-Failure-",
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges-PCI-Audit-Check-Ensure-Audit-Logon-is-set-to-Success-and-Failure-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Logon' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
@@ -337,7 +337,7 @@
                     "nodeGroupsOpen": true
                 },
                 {
-                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-2-3-Ensure-Audit-Distribution-Group-Management-is-set-to-Success-and-Failure-",
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges-PCI-Audit-Check-Ensure-Audit-Distribution-Group-Management-is-set-to-Success-and-Failure-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
@@ -371,7 +371,7 @@
                     "nodeGroupsOpen": true
                 },
                 {
-                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-2-5-Ensure-Audit-Security-Group-Management-is-set-to-Success-and-Failure-",
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges-PCI-Audit-Check-Ensure-Audit-Security-Group-Management-is-set-to-Success-and-Failure-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Security Group Management' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
@@ -405,7 +405,7 @@
                     "nodeGroupsOpen": true
                 },
                 {
-                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-5-L1-Ensure-Audit-Other-Logon-Logoff-Events-is-set-to-Success-and-Failure-",
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges-PCI-Audit-Check-Ensure-Audit-Other-Logon-Logoff-Events-is-set-to-Success-and-Failure-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
@@ -443,7 +443,7 @@
         {
             "10.2.6 Initialization, stopping, or pausing of the audit logs": [
                 {
-                    "id": "10-2-6-Initialization-stopping-or-pausing-of-the-audit-logs17-7-1-Ensure-Audit-Audit-Policy-Change-is-set-to-Success-and-Failure-",
+                    "id": "10-2-6-Initialization-stopping-or-pausing-of-the-audit-logs-PCI-Audit-Check-Ensure-Audit-Audit-Policy-Change-is-set-to-Success-and-Failure-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
@@ -477,7 +477,7 @@
                     "nodeGroupsOpen": true
                 },
                 {
-                    "id": "10-2-6-Initialization-stopping-or-pausing-of-the-audit-logs17-7-2-Ensure-Audit-Authentication-Policy-Change-is-set-to-Success-",
+                    "id": "10-2-6-Initialization-stopping-or-pausing-of-the-audit-logs-PCI-Audit-Check-Ensure-Audit-Authentication-Policy-Change-is-set-to-Success-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Authentication Policy Change' is set to 'Success'",
                     "error": false,
                     "checks": {
@@ -515,7 +515,7 @@
         {
             "10.2.7 Creation and deletion of system-level objects": [
                 {
-                    "id": "10-2-7-Creation-and-deletion-of-system-level-objects17-4-1-Ensure-Audit-Directory-Service-Access-is-set-to-Success-and-Failure-",
+                    "id": "10-2-7-Creation-and-deletion-of-system-level-objects-PCI-Audit-Check-Ensure-Audit-Directory-Service-Access-is-set-to-Success-and-Failure-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Directory Service Access' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
@@ -527,9 +527,9 @@
                         ],
                         "Directory Service Access": [
                             {
-                                "exp": "Success",
+                                "exp": "Success and Failure",
                                 "check": "equals",
-                                "expected": "Success",
+                                "expected": "Success and Failure",
                                 "background": "This subcategory reports when an AD DS object is accessed. Only objects with SACLs cause audit events to be generated, and only when they are accessed in a manner that matches their SACL. These events are similar to the directory service access events in previous versions of Windows Server. This subcategory applies only to domain controllers. Events for this subcategory include:\n4662 : An operation was performed on an object.\nThe recommended state for this setting is: Success and Failure .",
                                 "remediation": "To establish the recommended configuration via GP, set the following UI path to Success and Failure :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\DS Access\\Audit Directory Service Access"
                             }
@@ -549,7 +549,7 @@
                     "nodeGroupsOpen": true
                 },
                 {
-                    "id": "10-2-7-Creation-and-deletion-of-system-level-objects17-6-1-Ensure-Audit-Removable-Storage-is-set-to-Success-and-Failure-",
+                    "id": "10-2-7-Creation-and-deletion-of-system-level-objects-PCI-Audit-Check-Ensure-Audit-Removable-Storage-is-set-to-Success-and-Failure-",
                     "name": "[PCI: Audit-Check] Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
@@ -561,9 +561,9 @@
                         ],
                         "Removable Storage": [
                             {
-                                "exp": "Success And Failure",
+                                "exp": "Success and Failure",
                                 "check": "equals",
-                                "expected": "Success And Failure",
+                                "expected": "Success and Failure",
                                 "background": "This policy setting allows you to audit user attempts to access file system objects on a removable storage device. A security audit event is generated only for all objects for all types of access requested. If you configure this policy setting, an audit event is generated each time an account accesses a file system object on a removable storage. Success audits record successful attempts and Failure audits record unsuccessful attempts. If you do not configure this policy setting, no audit event is generated when an account accesses a file system object on a removable storage. The recommended state for this setting is: Success and Failure .",
                                 "remediation": "To establish the recommended configuration via GP, set the following UI path to Success and Failure :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Object Access\\Audit Removable Storage"
                             }
@@ -587,7 +587,7 @@
         {
             "Policy Version": [
                 {
-                    "id": "Policy-Version-PCI-Server-Hardening-Policy-Version",
+                    "id": "Policy-Version-PCI-Audit-Check-Policy-Version",
                     "name": "[PCI: Audit-Check] Policy Version",
                     "error": false,
                     "checks": {
@@ -601,7 +601,7 @@
                     "ci_path": null,
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "echo \"20170926-3\";",
+                        "query": "echo \"20170928-2\";",
                         "description": "[PCI: Audit-Check] Policy Version"
                     },
                     "description": "[PCI: Audit-Check] Policy Version",
@@ -678,7 +678,7 @@
             },
             {
                 "description": "[PCI: Audit-Check] Policy Version",
-                "query": "echo \"20170926-3\";"
+                "query": "echo \"20170928-2\";"
             }
         ]
     }

--- a/policies/PCI_3_2_Audit_Check_Windows.json
+++ b/policies/PCI_3_2_Audit_Check_Windows.json
@@ -41,11 +41,11 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.3.2 (L1) Ensure 'Audit Process Creation' is set to 'Success'"
+                        "17.3.1 Ensure 'Audit PNP Actiity' is set to 'Success'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Plug and Play\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"Plug and Play\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
                         "description": "17.3.1 Ensure 'Audit PNP Activity' is set to 'Success'"
                     },
                     "selectList": [
@@ -78,11 +78,11 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "The output of the PowerShell query {{ query }} should contain the specified value17.3.2 (L1) Ensure 'Audit Process Creation' is set to 'Success'"
+                        "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Process Creation\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"Process Creation\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
                         "description": "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'"
                     },
                     "description": "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'",
@@ -120,7 +120,7 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Other Account Management Events\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"Other Account Management Events\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
                         "description": "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'"
                     },
                     "description": "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'",
@@ -155,7 +155,7 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Account Lockout\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"Account Lockout\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
                         "description": "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'"
                     },
                     "description": "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'",
@@ -193,7 +193,7 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Computer Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"Computer Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
                         "description": "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'"
                     },
                     "description": "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'",
@@ -226,7 +226,7 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"User Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"User Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
                         "description": "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'"
                     },
                     "description": "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'",
@@ -234,7 +234,7 @@
                 },
                 {
                     "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-2-L1-Ensure-Audit-Group-Membership-is-set-to-Success-",
-                    "name": "17.5.2 (L1) Ensure 'Audit Group Membership' is set to 'Success'",
+                    "name": "17.5.2 Ensure 'Audit Group Membership' is set to 'Success'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -260,15 +260,15 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
-                        "description": "17.5.2 (L1) Ensure 'Audit Group Membership' is set to 'Success'"
+                        "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
+                        "description": "17.5.2 Ensure 'Audit Group Membership' is set to 'Success'"
                     },
-                    "description": "17.5.2 (L1) Ensure 'Audit Group Membership' is set to 'Success'",
+                    "description": "17.5.2 Ensure 'Audit Group Membership' is set to 'Success'",
                     "nodeGroupsOpen": true
                 },
                 {
                     "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-3-L1-Ensure-Audit-Logoff-is-set-to-Success-",
-                    "name": "17.5.3 (L1) Ensure 'Audit Logoff' is set to 'Success'",
+                    "name": "17.5.3 Ensure 'Audit Logoff' is set to 'Success'",
                     "error": false,
                     "checks": {
                         "Logoff": [
@@ -292,19 +292,19 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.5.3"
+                        "17.5.3 Ensure 'Audit Logoff' is set to 'Success'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logoff\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logoff\"  -Value \"Setting does not exists\";}      $obj;",
-                        "description": "17.5.3 (L1) Ensure 'Audit Logoff' is set to 'Success'"
+                        "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logoff\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logoff\"  -Value \"Setting does not exist\";}      $obj;",
+                        "description": "17.5.3 Ensure 'Audit Logoff' is set to 'Success'"
                     },
-                    "description": "17.5.3 (L1) Ensure 'Audit Logoff' is set to 'Success'",
+                    "description": "17.5.3 Ensure 'Audit Logoff' is set to 'Success'",
                     "nodeGroupsOpen": true
                 },
                 {
                     "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-4-L1-Ensure-Audit-Logon-is-set-to-Success-and-Failure-",
-                    "name": "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'",
+                    "name": "17.5.4 Ensure 'Audit Logon' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
                         "Logon": [
@@ -330,10 +330,10 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logon\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logon\"  -Value \"Setting does not exists\";}      $obj;",
-                        "description": "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'"
+                        "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logon\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logon\"  -Value \"Setting does not exist\";}      $obj;",
+                        "description": "17.5.4 Ensure 'Audit Logon' is set to 'Success and Failure'"
                     },
-                    "description": "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'",
+                    "description": "17.5.4 Ensure 'Audit Logon' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
                 },
                 {
@@ -364,7 +364,7 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Distribution Group Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"Distribution Group Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
                         "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'"
                     },
                     "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
@@ -398,7 +398,7 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Security Group Management\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;",
+                        "query": "$APolicySetting=\"Security Group Management\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exist\";} $obj;",
                         "description": "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'"
                     },
                     "description": "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'",
@@ -406,7 +406,7 @@
                 },
                 {
                     "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-5-L1-Ensure-Audit-Other-Logon-Logoff-Events-is-set-to-Success-and-Failure-",
-                    "name": "17.5.5 (L1) Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
+                    "name": "17.5.5 Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -428,14 +428,14 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.5.5 (L1) Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'"
+                        "17.5.5 Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Other Logon/Logoff Events\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;",
-                        "description": "17.5.5 (L1) Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'"
+                        "query": "$APolicySetting=\"Other Logon/Logoff Events\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exist\";} $obj;",
+                        "description": "17.5.5 Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'"
                     },
-                    "description": "17.5.5 (L1) Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
+                    "description": "17.5.5 Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
                 }
             ]
@@ -470,7 +470,7 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
                         "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'"
                     },
                     "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
@@ -504,7 +504,7 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Authentication Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"Authentication Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
                         "description": "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'"
                     },
                     "description": "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'",
@@ -542,7 +542,7 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Directory Service Access\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"Directory Service Access\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
                         "description": "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'"
                     },
                     "description": "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'",
@@ -576,7 +576,7 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Removable Storage\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"Removable Storage\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
                         "description": "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'"
                     },
                     "description": "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
@@ -601,7 +601,7 @@
                     "ci_path": null,
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "echo \"20170926-1\";",
+                        "query": "echo \"20170926-2\";",
                         "description": "[PCI: Server-Hardening] Policy Version"
                     },
                     "description": "[PCI: Server-Hardening] Policy Version",
@@ -614,71 +614,71 @@
         "powershell_queries": [
             {
                 "description": "17.3.1 Ensure 'Audit PNP Activity' is set to 'Success'",
-                "query": "$APolicySetting=\"Plug and Play\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Plug and Play\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
                 "description": "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'",
-                "query": "$APolicySetting=\"Process Creation\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Process Creation\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
                 "description": "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'",
-                "query": "$APolicySetting=\"Other Account Management Events\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Other Account Management Events\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
                 "description": "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'",
-                "query": "$APolicySetting=\"Account Lockout\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Account Lockout\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
                 "description": "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'",
-                "query": "$APolicySetting=\"Computer Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Computer Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
                 "description": "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'",
-                "query": "$APolicySetting=\"User Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"User Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.5.2 (L1) Ensure 'Audit Group Membership' is set to 'Success'",
-                "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "description": "17.5.2 Ensure 'Audit Group Membership' is set to 'Success'",
+                "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.5.3 (L1) Ensure 'Audit Logoff' is set to 'Success'",
-                "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logoff\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logoff\"  -Value \"Setting does not exists\";}      $obj;"
+                "description": "17.5.3 Ensure 'Audit Logoff' is set to 'Success'",
+                "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logoff\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logoff\"  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'",
-                "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logon\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logon\"  -Value \"Setting does not exists\";}      $obj;"
+                "description": "17.5.4 Ensure 'Audit Logon' is set to 'Success and Failure'",
+                "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logon\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logon\"  -Value \"Setting does not exist\";}      $obj;"
             },
             {
                 "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
-                "query": "$APolicySetting=\"Distribution Group Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Distribution Group Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
                 "description": "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'",
-                "query": "$APolicySetting=\"Security Group Management\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;"
+                "query": "$APolicySetting=\"Security Group Management\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exist\";} $obj;"
             },
             {
-                "description": "17.5.5 (L1) Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
-                "query": "$APolicySetting=\"Other Logon/Logoff Events\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;"
+                "description": "17.5.5 Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
+                "query": "$APolicySetting=\"Other Logon/Logoff Events\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exist\";} $obj;"
             },
             {
                 "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
-                "query": "$APolicySetting=\"Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
                 "description": "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'",
-                "query": "$APolicySetting=\"Authentication Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Authentication Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
                 "description": "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'",
-                "query": "$APolicySetting=\"Directory Service Access\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Directory Service Access\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
                 "description": "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
-                "query": "$APolicySetting=\"Removable Storage\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Removable Storage\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
                 "description": "[PCI: Server-Hardening] Policy Version",
-                "query": "echo \"20170926-1\";"
+                "query": "echo \"20170926-2\";"
             }
         ]
     }

--- a/policies/PCI_3_2_Audit_Check_Windows.json
+++ b/policies/PCI_3_2_Audit_Check_Windows.json
@@ -80,7 +80,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Process Creation\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"Process Creation\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "description": "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'"
                     },
                     "description": "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'",
                     "nodeGroupsOpen": true
@@ -117,7 +118,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Other Account Management Events\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"Other Account Management Events\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "description": "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'"
                     },
                     "description": "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
@@ -151,7 +153,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Account Lockout\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"Account Lockout\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "description": "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'"
                     },
                     "description": "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
@@ -188,7 +191,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Computer Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"Computer Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "description": "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'"
                     },
                     "description": "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
@@ -220,7 +224,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"User Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"User Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "description": "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'"
                     },
                     "description": "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
@@ -253,7 +258,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "description": "17.5.2 (L1) Ensure 'Audit Group Membership' is set to 'Success'"
                     },
                     "description": "17.5.2 (L1) Ensure 'Audit Group Membership' is set to 'Success'",
                     "nodeGroupsOpen": true
@@ -286,7 +292,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "description": "17.5.3 (L1) Ensure 'Audit Logoff' is set to 'Success'"
                     },
                     "description": "17.5.3 (L1) Ensure 'Audit Logoff' is set to 'Success'",
                     "nodeGroupsOpen": true
@@ -329,7 +336,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "description": "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'"
                     },
                     "description": "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
@@ -362,7 +370,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Distribution Group Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"Distribution Group Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                       "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'"
                     },
                     "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
@@ -395,7 +404,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Security Group Management\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;"
+                        "query": "$APolicySetting=\"Security Group Management\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;",
+                        "description": "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'"
                     },
                     "description": "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
@@ -428,7 +438,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Other Logon/Logoff Events\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;"
+                        "query": "$APolicySetting=\"Other Logon/Logoff Events\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;",
+                        "description": "17.5.5 (L1) Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'"
                     },
                     "description": "17.5.5 (L1) Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
@@ -469,7 +480,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                         "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'"
                     },
                     "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
@@ -510,7 +522,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Authentication Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"Authentication Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "description": "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'"
                     },
                     "description": "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'",
                     "nodeGroupsOpen": true
@@ -547,7 +560,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Directory Service Access\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"Directory Service Access\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "description": "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'"
                     },
                     "description": "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
@@ -580,7 +594,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Removable Storage\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"Removable Storage\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "description": "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'"
                     },
                     "description": "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
@@ -595,63 +610,63 @@
                 "query": "$APolicySetting=\"Plug and Play\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
-                "description": null,
+                "description": "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'",
                 "query": "$APolicySetting=\"Process Creation\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
-                "description": null,
+                "description": "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Other Account Management Events\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
-                "description": null,
+                "description": "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Account Lockout\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
-                "description": null,
+                "description": "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Computer Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
-                "description": null,
+                "description": "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"User Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
-                "description": null,
+                "description": "17.5.2 (L1) Ensure 'Audit Group Membership' is set to 'Success'",
                 "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
-                "description": null,
+                "description": "17.5.3 (L1) Ensure 'Audit Logoff' is set to 'Success'",
                 "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
-                "description": null,
+                "description": "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
-                "description": null,
+                "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Distribution Group Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
-                "description": null,
+                "description": "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Security Group Management\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;"
             },
             {
-                "description": null,
+                "description": "17.5.5 (L1) Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Other Logon/Logoff Events\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;"
             },
             {
-                "description": null,
-                "query": "$APolicySetting=\"Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
+                "query": "$APolicySetting=\"Audit Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
-                "description": null,
+                "description": "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'",
                 "query": "$APolicySetting=\"Authentication Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
-                "description": null,
+                "description": "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Directory Service Access\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
-                "description": null,
+                "description": "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Removable Storage\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             }
         ]

--- a/policies/PCI_3_2_Audit_Check_Windows.json
+++ b/policies/PCI_3_2_Audit_Check_Windows.json
@@ -43,7 +43,8 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Plug and Play\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                        "query": "$APolicySetting=\"Plug and Play\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "description": "17.3.1 Ensure 'Audit PNP Activity' is set to 'Success'"
                     },
                     "selectList": [
                         "*"
@@ -590,7 +591,7 @@
     "scan_options": {
         "powershell_queries": [
             {
-                "description": null,
+                "description": "17.3.1 Ensure 'Audit PNP Activity' is set to 'Success'",
                 "query": "$APolicySetting=\"Plug and Play\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {

--- a/policies/PCI_3_2_Audit_Check_Windows.json
+++ b/policies/PCI_3_2_Audit_Check_Windows.json
@@ -17,7 +17,7 @@
             "10.1 Implement audit trails to link all access to system components to each individual user.": [
                 {
                     "id": "10-1-Implement-audit-trails-to-link-all-access-to-system-components-to-each-individual-user-17-3-1-Ensure-Audit-PNP-Activity-is-set-to-Success-",
-                    "name": "17.3.1 Ensure 'Audit PNP Activity' is set to 'Success'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit PNP Activity' is set to 'Success'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -41,22 +41,22 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.3.1 Ensure 'Audit PNP Actiity' is set to 'Success'"
+                        "[PCI: Audit-Check] Ensure 'Audit PNP Actiity' is set to 'Success'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Plug and Play\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.3.1 Ensure 'Audit PNP Activity' is set to 'Success'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit PNP Activity' is set to 'Success'"
                     },
                     "selectList": [
                         "*"
                     ],
-                    "description": "17.3.1 Ensure 'Audit PNP Activity' is set to 'Success'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit PNP Activity' is set to 'Success'",
                     "nodeGroupsOpen": true
                 },
                 {
                     "id": "10-1-Implement-audit-trails-to-link-all-access-to-system-components-to-each-individual-user-17-3-2-Ensure-Audit-Process-Creation-is-set-to-Success-",
-                    "name": "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Process Creation' is set to 'Success'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -78,14 +78,14 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'"
+                        "[PCI: Audit-Check] Ensure 'Audit Process Creation' is set to 'Success'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Process Creation\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Process Creation' is set to 'Success'"
                     },
-                    "description": "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Process Creation' is set to 'Success'",
                     "nodeGroupsOpen": true
                 }
             ]
@@ -94,7 +94,7 @@
             "10.2.4 Verify invalid logical access attempts are logged.": [
                 {
                     "id": "10-2-4-Verify-invalid-logical-access-attempts-are-logged-17-2-4-Ensure-Audit-Other-Account-Management-Events-is-set-to-Success-and-Failure-",
-                    "name": "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -116,19 +116,19 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'"
+                        "[PCI: Audit-Check] Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Other Account Management Events\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'"
                     },
-                    "description": "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
                 },
                 {
                     "id": "10-2-4-Verify-invalid-logical-access-attempts-are-logged-17-5-1-Ensure-Audit-Account-Lockout-is-set-to-Success-and-Failure-",
-                    "name": "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Account Lockout' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -151,14 +151,14 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'"
+                        "[PCI: Audit-Check] Ensure 'Audit Account Lockout' is set to 'Success and Failure'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Account Lockout\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Account Lockout' is set to 'Success and Failure'"
                     },
-                    "description": "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Account Lockout' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
                 }
             ]
@@ -167,7 +167,7 @@
             "10.2.5 Use of and changes to identification and authentication mechanisms—including but not limited to creation of new accounts and elevation of privileges—and all changes, additions, or deletions to accounts with root or administrative privileges": [
                 {
                     "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-2-2-Ensure-Audit-Computer-Account-Management-is-set-to-Success-and-Failure-",
-                    "name": "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Computer Account Management' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -189,19 +189,19 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'"
+                        "[PCI: Audit-Check] Ensure 'Audit Computer Account Management' is set to 'Success and Failure'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Computer Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Computer Account Management' is set to 'Success and Failure'"
                     },
-                    "description": "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Computer Account Management' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
                 },
                 {
                     "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-2-6-Ensure-Audit-User-Account-Management-is-set-to-Success-and-Failure-",
-                    "name": "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit User Account Management' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -222,19 +222,19 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'"
+                        "[PCI: Audit-Check] Ensure 'Audit User Account Management' is set to 'Success and Failure'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"User Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit User Account Management' is set to 'Success and Failure'"
                     },
-                    "description": "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit User Account Management' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
                 },
                 {
                     "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-2-L1-Ensure-Audit-Group-Membership-is-set-to-Success-",
-                    "name": "17.5.2 Ensure 'Audit Group Membership' is set to 'Success'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Group Membership' is set to 'Success'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -261,14 +261,14 @@
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.5.2 Ensure 'Audit Group Membership' is set to 'Success'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Group Membership' is set to 'Success'"
                     },
-                    "description": "17.5.2 Ensure 'Audit Group Membership' is set to 'Success'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Group Membership' is set to 'Success'",
                     "nodeGroupsOpen": true
                 },
                 {
                     "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-3-L1-Ensure-Audit-Logoff-is-set-to-Success-",
-                    "name": "17.5.3 Ensure 'Audit Logoff' is set to 'Success'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Logoff' is set to 'Success'",
                     "error": false,
                     "checks": {
                         "Logoff": [
@@ -292,19 +292,19 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.5.3 Ensure 'Audit Logoff' is set to 'Success'"
+                        "[PCI: Audit-Check] Ensure 'Audit Logoff' is set to 'Success'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logoff\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logoff\"  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.5.3 Ensure 'Audit Logoff' is set to 'Success'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Logoff' is set to 'Success'"
                     },
-                    "description": "17.5.3 Ensure 'Audit Logoff' is set to 'Success'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Logoff' is set to 'Success'",
                     "nodeGroupsOpen": true
                 },
                 {
                     "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-4-L1-Ensure-Audit-Logon-is-set-to-Success-and-Failure-",
-                    "name": "17.5.4 Ensure 'Audit Logon' is set to 'Success and Failure'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Logon' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
                         "Logon": [
@@ -331,14 +331,14 @@
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logon\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logon\"  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.5.4 Ensure 'Audit Logon' is set to 'Success and Failure'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Logon' is set to 'Success and Failure'"
                     },
-                    "description": "17.5.4 Ensure 'Audit Logon' is set to 'Success and Failure'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Logon' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
                 },
                 {
                     "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-2-3-Ensure-Audit-Distribution-Group-Management-is-set-to-Success-and-Failure-",
-                    "name": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -360,19 +360,19 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'"
+                        "[PCI: Audit-Check] Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Distribution Group Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'"
                     },
-                    "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
                 },
                 {
                     "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-2-5-Ensure-Audit-Security-Group-Management-is-set-to-Success-and-Failure-",
-                    "name": "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Security Group Management' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -394,19 +394,19 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'"
+                        "[PCI: Audit-Check] Ensure 'Audit Security Group Management' is set to 'Success and Failure'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Security Group Management\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exist\";} $obj;",
-                        "description": "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Security Group Management' is set to 'Success and Failure'"
                     },
-                    "description": "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Security Group Management' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
                 },
                 {
                     "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-5-L1-Ensure-Audit-Other-Logon-Logoff-Events-is-set-to-Success-and-Failure-",
-                    "name": "17.5.5 Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -428,14 +428,14 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.5.5 Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'"
+                        "[PCI: Audit-Check] Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Other Logon/Logoff Events\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exist\";} $obj;",
-                        "description": "17.5.5 Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'"
                     },
-                    "description": "17.5.5 Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
                 }
             ]
@@ -444,7 +444,7 @@
             "10.2.6 Initialization, stopping, or pausing of the audit logs": [
                 {
                     "id": "10-2-6-Initialization-stopping-or-pausing-of-the-audit-logs17-7-1-Ensure-Audit-Audit-Policy-Change-is-set-to-Success-and-Failure-",
-                    "name": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -466,19 +466,19 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'"
+                        "[PCI: Audit-Check] Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'"
                     },
-                    "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
                 },
                 {
                     "id": "10-2-6-Initialization-stopping-or-pausing-of-the-audit-logs17-7-2-Ensure-Audit-Authentication-Policy-Change-is-set-to-Success-",
-                    "name": "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Authentication Policy Change' is set to 'Success'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -500,14 +500,14 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'"
+                        "[PCI: Audit-Check] Ensure 'Audit Authentication Policy Change' is set to 'Success'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Authentication Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Authentication Policy Change' is set to 'Success'"
                     },
-                    "description": "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Authentication Policy Change' is set to 'Success'",
                     "nodeGroupsOpen": true
                 }
             ]
@@ -516,7 +516,7 @@
             "10.2.7 Creation and deletion of system-level objects": [
                 {
                     "id": "10-2-7-Creation-and-deletion-of-system-level-objects17-4-1-Ensure-Audit-Directory-Service-Access-is-set-to-Success-and-Failure-",
-                    "name": "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Directory Service Access' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -538,19 +538,19 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'"
+                        "[PCI: Audit-Check] Ensure 'Audit Directory Service Access' is set to 'Success and Failure'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Directory Service Access\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Directory Service Access' is set to 'Success and Failure'"
                     },
-                    "description": "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Directory Service Access' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
                 },
                 {
                     "id": "10-2-7-Creation-and-deletion-of-system-level-objects17-6-1-Ensure-Audit-Removable-Storage-is-set-to-Success-and-Failure-",
-                    "name": "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
+                    "name": "[PCI: Audit-Check] Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
                     "error": false,
                     "checks": {
                         "present": [
@@ -572,14 +572,14 @@
                     "ci_path": [
                         "PowerShell",
                         "Queries",
-                        "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'"
+                        "[PCI: Audit-Check] Ensure 'Audit Removable Storage' is set to 'Success and Failure'"
                     ],
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Removable Storage\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;",
-                        "description": "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'"
+                        "description": "[PCI: Audit-Check] Ensure 'Audit Removable Storage' is set to 'Success and Failure'"
                     },
-                    "description": "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
+                    "description": "[PCI: Audit-Check] Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
                 }
             ]
@@ -588,7 +588,7 @@
             "Policy Version": [
                 {
                     "id": "Policy-Version-PCI-Server-Hardening-Policy-Version",
-                    "name": "[PCI: Server-Hardening] Policy Version",
+                    "name": "[PCI: Audit-Check] Policy Version",
                     "error": false,
                     "checks": {
                         "present": [
@@ -601,10 +601,10 @@
                     "ci_path": null,
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "echo \"20170926-2\";",
-                        "description": "[PCI: Server-Hardening] Policy Version"
+                        "query": "echo \"20170926-3\";",
+                        "description": "[PCI: Audit-Check] Policy Version"
                     },
-                    "description": "[PCI: Server-Hardening] Policy Version",
+                    "description": "[PCI: Audit-Check] Policy Version",
                     "nodeGroupsOpen": true
                 }
             ]
@@ -613,72 +613,72 @@
     "scan_options": {
         "powershell_queries": [
             {
-                "description": "17.3.1 Ensure 'Audit PNP Activity' is set to 'Success'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit PNP Activity' is set to 'Success'",
                 "query": "$APolicySetting=\"Plug and Play\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Process Creation' is set to 'Success'",
                 "query": "$APolicySetting=\"Process Creation\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Other Account Management Events\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Account Lockout' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Account Lockout\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Computer Account Management' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Computer Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit User Account Management' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"User Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.5.2 Ensure 'Audit Group Membership' is set to 'Success'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Group Membership' is set to 'Success'",
                 "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.5.3 Ensure 'Audit Logoff' is set to 'Success'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Logoff' is set to 'Success'",
                 "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logoff\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logoff\"  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.5.4 Ensure 'Audit Logon' is set to 'Success and Failure'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Logon' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logon\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logon\"  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Distribution Group Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Security Group Management' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Security Group Management\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exist\";} $obj;"
             },
             {
-                "description": "17.5.5 Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Other Logon/Logoff Events\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exist\";} $obj;"
             },
             {
-                "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Authentication Policy Change' is set to 'Success'",
                 "query": "$APolicySetting=\"Authentication Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Directory Service Access' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Directory Service Access\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
+                "description": "[PCI: Audit-Check] Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Removable Storage\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exist\";}      $obj;"
             },
             {
-                "description": "[PCI: Server-Hardening] Policy Version",
-                "query": "echo \"20170926-2\";"
+                "description": "[PCI: Audit-Check] Policy Version",
+                "query": "echo \"20170926-3\";"
             }
         ]
     }

--- a/policies/PCI_3_2_Audit_Check_Windows.json
+++ b/policies/PCI_3_2_Audit_Check_Windows.json
@@ -371,7 +371,7 @@
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Distribution Group Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
-                       "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'"
+                        "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'"
                     },
                     "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
@@ -481,7 +481,7 @@
                     "check_type": "powershell",
                     "powershell": {
                         "query": "$APolicySetting=\"Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
-                         "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'"
+                        "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'"
                     },
                     "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
                     "nodeGroupsOpen": true
@@ -601,6 +601,29 @@
                     "nodeGroupsOpen": true
                 }
             ]
+        },
+        {
+            "Policy Version": [
+                {
+                    "name": "[PCI: Server-Hardening] Policy Version",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ]
+                    },
+                    "ci_path": null,
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "echo \"20170925-1\";",
+                        "description": "[PCI: Server-Hardening] Policy Version"
+                    },
+                    "description": "[PCI: Server-Hardening] Policy Version"
+                }
+            ]
         }
     ],
     "scan_options": {
@@ -655,7 +678,7 @@
             },
             {
                 "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
-                "query": "$APolicySetting=\"Audit Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
             },
             {
                 "description": "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'",
@@ -668,6 +691,10 @@
             {
                 "description": "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
                 "query": "$APolicySetting=\"Removable Storage\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": "[PCI: Server-Hardening] Policy Version",
+                "query": "echo \"20170925-1\";"
             }
         ]
     }

--- a/policies/PCI_3_2_Audit_Check_Windows.json
+++ b/policies/PCI_3_2_Audit_Check_Windows.json
@@ -26,13 +26,15 @@
                                 "expected": "true"
                             }
                         ],
-                        "Plug and Play Events": [
+                        "Plug And Play": [
                             {
-                                "exp": "Success",
                                 "check": "equals",
                                 "expected": "Success",
                                 "background": "This policy setting allows you to audit when plug and play detects an external device. The recommended state for this setting is: Success .",
-                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Detailed Tracking\\Audit PNP Activity"
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success : Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Detailed Tracking\\Audit PNP Activity",
+                                "valueSelectList": null,
+                                "attributeSelectList": null,
+                                "availableAttributes": null
                             }
                         ]
                     },
@@ -271,11 +273,13 @@
                     "checks": {
                         "Logoff": [
                             {
-                                "exp": "Success",
                                 "check": "equals",
                                 "expected": "Success",
-                                "background": "This subcategory reports when a user logs off from the system. These events occur on the accessed computer. For interactive logons, the generation of these events occurs on the computer that is logged on to. If a network logon takes place to access a share, these events generate on the computer that hosts the accessed resource. If you configure this setting to No auditing, it is difficult or impossible to determine which user has accessed or attempted to access organization computers. Events for this subcategory include:\n4634: An account was logged off.\n4647: User initiated logoff.\nThe recommended state for this setting is: Success .",
-                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff\\Audit Logoff"
+                                "background": "This subcategory reports when a user logs off from the system. These events occur on the accessed computer. For interactive logons, the generation of these events occurs on the computer that is logged on to. If a network logon takes place to access a share, these events generate on the computer that hosts the accessed resource. If you configure this setting to No auditing, it is difficult or impossible to determine which user has accessed or attempted to access organization computers. Events for this subcategory include: 4634: An account was logged off. 4647: User initiated logoff. The recommended state for this setting is: Success .",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success : Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff\\Audit Logoff",
+                                "valueSelectList": null,
+                                "attributeSelectList": null,
+                                "availableAttributes": null
                             }
                         ],
                         "present": [
@@ -292,7 +296,7 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logoff\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logoff\"  -Value \"Setting does not exists\";}      $obj;",
                         "description": "17.5.3 (L1) Ensure 'Audit Logoff' is set to 'Success'"
                     },
                     "description": "17.5.3 (L1) Ensure 'Audit Logoff' is set to 'Success'",
@@ -326,7 +330,7 @@
                     ],
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;",
+                        "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logon\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logon\"  -Value \"Setting does not exists\";}      $obj;",
                         "description": "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'"
                     },
                     "description": "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'",
@@ -451,17 +455,11 @@
                         ],
                         "Policy Change": [
                             {
+                                "exp": "Success and Failure",
                                 "check": "equals",
                                 "expected": "Success and Failure",
-                                "valueSelectList": null,
-                                "attributeSelectList": [
-                                    "User Account Management"
-                                ],
-                                "availableAttributes": [
-                                    {
-                                        "User Account Management": "Success"
-                                    }
-                                ]
+                                "background": "This subcategory reports changes in audit policy including SACL changes. Events for this\nsubcategory include:\n4715: The audit policy (SACL) on an object was changed.\n4719: System audit policy was changed.\n4902: The Per-user audit policy table was created.\n4904: An attempt was made to register a security event source.\n4905: An attempt was made to unregister a security event source.\n4906: The CrashOnAuditFail value has changed.\n4907: Auditing settings on object were changed.\n4908: Special Groups Logon table modified.\n4912: Per User Audit Policy was changed.",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success\nand Failure : Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Policy Change\\Audit Audit Policy Change"
                             }
                         ]
                     },
@@ -491,19 +489,11 @@
                         ],
                         "Authentication Policy Change": [
                             {
+                                "exp": "Success",
                                 "check": "equals",
                                 "expected": "Success",
-                                "valueSelectList": [
-                                    "Success"
-                                ],
-                                "attributeSelectList": [
-                                    "Authentication Policy Change"
-                                ],
-                                "availableAttributes": [
-                                    {
-                                        "Authentication Policy Change": "Success"
-                                    }
-                                ]
+                                "background": "This subcategory reports changes in authentication policy. Events for this subcategory include: 4706: A new trust was created to a domain. 4707: A trust to a domain was removed. 4713: Kerberos policy was changed. 4716: Trusted domain information was modified. 4717: System security access was granted to an account. 4718: System security access was removed from an account. 4739: Domain Policy was changed. 4864: A namespace collision was detected. 4865: A trusted forest information entry was added. 4866: A trusted forest information entry was removed. 4867: A trusted forest information entry was modified.",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success : Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Policy Change\\Audit Authentication Policy Change"
                             }
                         ]
                     },
@@ -611,7 +601,7 @@
                     "ci_path": null,
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "echo \"20170926-0\";",
+                        "query": "echo \"20170926-1\";",
                         "description": "[PCI: Server-Hardening] Policy Version"
                     },
                     "description": "[PCI: Server-Hardening] Policy Version",
@@ -652,11 +642,11 @@
             },
             {
                 "description": "17.5.3 (L1) Ensure 'Audit Logoff' is set to 'Success'",
-                "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logoff\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logoff\"  -Value \"Setting does not exists\";}      $obj;"
             },
             {
                 "description": "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'",
-                "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name \"Logon\" -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name \"Logon\"  -Value \"Setting does not exists\";}      $obj;"
             },
             {
                 "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
@@ -688,7 +678,7 @@
             },
             {
                 "description": "[PCI: Server-Hardening] Policy Version",
-                "query": "echo \"20170926-0\";"
+                "query": "echo \"20170926-1\";"
             }
         ]
     }

--- a/policies/PCI_3_2_Audit_Check_Windows.json
+++ b/policies/PCI_3_2_Audit_Check_Windows.json
@@ -1,0 +1,658 @@
+{
+    "policy": {
+        "name": "pci_32_audit_checks_--_windows",
+        "short_description": "PCI 3.2 Audit Checks -- Windows",
+        "description": null,
+        "settings": {
+            "tests": {
+                "output_format": null
+            }
+        },
+        "operating_system_family_id": null,
+        "operating_system_id": null,
+        "type": null
+    },
+    "data": [
+        {
+            "10.1 Implement audit trails to link all access to system components to each individual user.": [
+                {
+                    "id": "10-1-Implement-audit-trails-to-link-all-access-to-system-components-to-each-individual-user-17-3-1-Ensure-Audit-PNP-Activity-is-set-to-Success-",
+                    "name": "17.3.1 Ensure 'Audit PNP Activity' is set to 'Success'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "Plug and Play Events": [
+                            {
+                                "exp": "Success",
+                                "check": "equals",
+                                "expected": "Success",
+                                "background": "This policy setting allows you to audit when plug and play detects an external device. The recommended state for this setting is: Success .",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Detailed Tracking\\Audit PNP Activity"
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.3.2 (L1) Ensure 'Audit Process Creation' is set to 'Success'"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Plug and Play\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "selectList": [
+                        "*"
+                    ],
+                    "description": "17.3.1 Ensure 'Audit PNP Activity' is set to 'Success'",
+                    "nodeGroupsOpen": true
+                },
+                {
+                    "id": "10-1-Implement-audit-trails-to-link-all-access-to-system-components-to-each-individual-user-17-3-2-Ensure-Audit-Process-Creation-is-set-to-Success-",
+                    "name": "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "Process Creation": [
+                            {
+                                "exp": "Success",
+                                "check": "equals",
+                                "expected": "Success",
+                                "background": "This subcategory reports the creation of a process and the name of the program or user that created it. Events for this subcategory include:\n1. 4688: A new process has been created.\n2. 4696: A primary token was assigned to process.",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Detailed Tracking\\Audit Process Creation"
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "The output of the PowerShell query {{ query }} should contain the specified value17.3.2 (L1) Ensure 'Audit Process Creation' is set to 'Success'"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Process Creation\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "description": "17.3.2 Ensure 'Audit Process Creation' is set to 'Success'",
+                    "nodeGroupsOpen": true
+                }
+            ]
+        },
+        {
+            "10.2.4 Verify invalid logical access attempts are logged.": [
+                {
+                    "id": "10-2-4-Verify-invalid-logical-access-attempts-are-logged-17-2-4-Ensure-Audit-Other-Account-Management-Events-is-set-to-Success-and-Failure-",
+                    "name": "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "Other Account Management Events": [
+                            {
+                                "exp": "Success and Failure",
+                                "check": "equals",
+                                "expected": "Success and Failure",
+                                "background": "This subcategory reports other account management events. Events for this subcategory include:\n4782: The password hash an account was accessed.\n4793: The Password Policy Checking API was called.",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success and Failure:\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management\\Audit Other Account Management Events"
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Other Account Management Events\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "description": "17.2.4 Ensure 'Audit Other Account Management Events' is set to 'Success and Failure'",
+                    "nodeGroupsOpen": true
+                },
+                {
+                    "id": "10-2-4-Verify-invalid-logical-access-attempts-are-logged-17-5-1-Ensure-Audit-Account-Lockout-is-set-to-Success-and-Failure-",
+                    "name": "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "Account Lockout": [
+                            {
+                                "exp": "Success and Failure",
+                                "check": "equals",
+                                "expected": "Success and Failure",
+                                "background": "This subcategory reports when a user's account is locked out as a result of too many failed logon attempts. Events for this subcategory include:\n4625: An account failed to log on.\nThe recommended state for this setting is: Success and Failure .",
+                                "absent_pass": false,
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success and Failure :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff\\Audit Account Lockout"
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Account Lockout\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "description": "17.5.1 Ensure 'Audit Account Lockout' is set to 'Success and Failure'",
+                    "nodeGroupsOpen": true
+                }
+            ]
+        },
+        {
+            "10.2.5 Use of and changes to identification and authentication mechanisms—including but not limited to creation of new accounts and elevation of privileges—and all changes, additions, or deletions to accounts with root or administrative privileges": [
+                {
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-2-2-Ensure-Audit-Computer-Account-Management-is-set-to-Success-and-Failure-",
+                    "name": "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "Computer Account Management": [
+                            {
+                                "exp": "Success and Failure",
+                                "check": "equals",
+                                "expected": "Success and Failure",
+                                "background": "This subcategory reports each event of computer account management, such as when a computer account is created, changed, deleted, renamed, disabled, or enabled. Events for this subcategory include:\n4741: A computer account was created.\n4742: A computer account was changed.\n4743: A computer account was deleted.\nThe recommended state for this setting is: Success and Failure .",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success and Failure :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management\\Audit Computer Account Management"
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Computer Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "description": "17.2.2 Ensure 'Audit Computer Account Management' is set to 'Success and Failure'",
+                    "nodeGroupsOpen": true
+                },
+                {
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-2-6-Ensure-Audit-User-Account-Management-is-set-to-Success-and-Failure-",
+                    "name": "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "User Account Management": [
+                            {
+                                "exp": "Success and Failure",
+                                "check": "equals",
+                                "expected": "Success and Failure",
+                                "background": "This subcategory reports each event of user account management, such as when a user account is created, changed, or deleted; a user account is renamed, disabled, or enabled; or a password is set or changed. If you enable this Audit policy setting, administrators can track events to detect malicious, accidental, and authorized creation of user accounts. Events for this subcategory include:\n4720: A user account was created.\n4722: A user account was enabled.\n4723: An attempt was made to change an account's password.\n4724: An attempt was made to reset an account's password.\n4725: A user account was disabled.\n4726: A user account was deleted.\n4738: A user account was changed.\n4740: A user account was locked out.\n4765: SID History was added to an account.\n4766: An attempt to add SID History to an account failed.\n4767: A user account was unlocked.\n4780: The ACL was set on accounts which are members of administrators groups.\n4781: The name of an account was changed:\n4794: An attempt was made to set the Directory Services Restore Mode.\n5376: Credential Manager credentials were backed up.\n5377: Credential Manager credentials were restored from a backup.\nThe recommended state for this setting is: Success and Failure ."
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"User Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "description": "17.2.6 Ensure 'Audit User Account Management' is set to 'Success and Failure'",
+                    "nodeGroupsOpen": true
+                },
+                {
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-2-L1-Ensure-Audit-Group-Membership-is-set-to-Success-",
+                    "name": "17.5.2 (L1) Ensure 'Audit Group Membership' is set to 'Success'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "Group Membership": [
+                            {
+                                "exp": "Success",
+                                "check": "equals",
+                                "expected": "Success",
+                                "background": "This policy allows you to audit the group membership information in the user’s logon token. Events in this subcategory are generated on the computer on which a logon session is created. For an interactive logon, the security audit event is generated on the computer that the user logged on to. For a network logon, such as accessing a shared folder on the network, the security audit event is generated on the computer hosting the resource. The recommended state for this setting is: Success .",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff\\Audit Group Membership"
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.5.2"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "description": "17.5.2 (L1) Ensure 'Audit Group Membership' is set to 'Success'",
+                    "nodeGroupsOpen": true
+                },
+                {
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-3-L1-Ensure-Audit-Logoff-is-set-to-Success-",
+                    "name": "17.5.3 (L1) Ensure 'Audit Logoff' is set to 'Success'",
+                    "error": false,
+                    "checks": {
+                        "Logoff": [
+                            {
+                                "exp": "Success",
+                                "check": "equals",
+                                "expected": "Success",
+                                "background": "This subcategory reports when a user logs off from the system. These events occur on the accessed computer. For interactive logons, the generation of these events occurs on the computer that is logged on to. If a network logon takes place to access a share, these events generate on the computer that hosts the accessed resource. If you configure this setting to No auditing, it is difficult or impossible to determine which user has accessed or attempted to access organization computers. Events for this subcategory include:\n4634: An account was logged off.\n4647: User initiated logoff.\nThe recommended state for this setting is: Success .",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff\\Audit Logoff"
+                            }
+                        ],
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.5.3"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "description": "17.5.3 (L1) Ensure 'Audit Logoff' is set to 'Success'",
+                    "nodeGroupsOpen": true
+                },
+                {
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-4-L1-Ensure-Audit-Logon-is-set-to-Success-and-Failure-",
+                    "name": "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'",
+                    "error": false,
+                    "checks": {
+                        "Logon": [
+                            {
+                                "check": "equals",
+                                "expected": "Success and Failure",
+                                "valueSelectList": null,
+                                "attributeSelectList": null,
+                                "availableAttributes": null
+                            },
+                            {
+                                "name": "Logon",
+                                "path": [
+                                    "10.2.5 Use of and changes to identification and authentication mechanisms—including but not limited to creation of new accounts and elevation of privileges—and all changes, additions, or deletions to accounts with root or administrative privileges",
+                                    "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'"
+                                ],
+                                "check": "equals",
+                                "background": "This subcategory reports when a user attempts to log on to the system. These events occur on the accessed computer. For interactive logons, the generation of these events occurs on the computer that is logged on to. If a network logon takes place to access a share, these events generate on the computer that hosts the accessed resource. If you configure this setting to No auditing, it is difficult or impossible to determine which user has accessed or attempted to access organization computers. Events for this subcategory include:\n4624: An account was successfully logged on.\n4625: An account failed to log on.\n4648: A logon was attempted using explicit credentials.\n4675: SIDs were filtered.\nThe recommended state for this setting is: Success and Failure .",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success and Failure :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff\\Audit Logon"
+                            }
+                        ],
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.5.4"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "description": "17.5.4 (L1) Ensure 'Audit Logon' is set to 'Success and Failure'",
+                    "nodeGroupsOpen": true
+                },
+                {
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-2-3-Ensure-Audit-Distribution-Group-Management-is-set-to-Success-and-Failure-",
+                    "name": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "Distribution Group Management": [
+                            {
+                                "exp": "Success and Failure",
+                                "check": "equals",
+                                "expected": "Success and Failure",
+                                "background": "This subcategory reports each event of distribution group management, such as when a distribution group is created, changed, or deleted or when a member is added to or removed from a distribution group. If you enable this Audit policy setting, administrators can track events to detect malicious, accidental, and authorized creation of group accounts.Events for this subcategory include:\n4744: A security-disabled local group was created.\n4745: A security-disabled local group was changed.\n4746: A member was added to a security-disabled local group.\n4747: A member was removed from a security-disabled local group.\n4748: A security-disabled local group was deleted.\n4749: A security-disabled global group was created.\n4750: A security-disabled global group was changed.\n4751: A member was added to a security-disabled global group.\n4752: A member was removed from a security-disabled global group.\n4753: A security-disabled global group was deleted.\n4759: A security-disabled universal group was created.\n4760: A security-disabled universal group was changed.\n4761: A member was added to a security-disabled universal group.\n4762: A member was removed from a security-disabled universal group.\n4763: A security-disabled universal group was deleted.\nThe recommended state for this setting is: Success and Failure .",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success and Failure :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management\\Audit Distribution Group Management"
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Distribution Group Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "description": "17.2.3 Ensure 'Audit Distribution Group Management' is set to 'Success and Failure'",
+                    "nodeGroupsOpen": true
+                },
+                {
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-2-5-Ensure-Audit-Security-Group-Management-is-set-to-Success-and-Failure-",
+                    "name": "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "Security Group Management": [
+                            {
+                                "exp": "Success and Failure",
+                                "check": "equals",
+                                "expected": "Success and Failure",
+                                "background": "This subcategory reports each event of security group management, such as when a security group is created, changed, or deleted or when a member is added to or removed from a security group. If you enable this Audit policy setting, administrators can track events to detect malicious, accidental, and authorized creation of security group accounts. Events for this subcategory include: \n4727: A security-enabled global group was created.\n4728: A member was added to a security-enabled global group.\n4729: A member was removed from a security-enabled global group.\n4730: A security-enabled global group was deleted.\n4731: A security-enabled local group was created.\n4732: A member was added to a security-enabled local group.\n4733: A member was removed from a security-enabled local group.\n4734: A security-enabled local group was deleted.\n4735: A security-enabled local group was changed.\n4737: A security-enabled global group was changed.\n4754: A security-enabled universal group was created.\n4755: A security-enabled universal group was changed.\n4756: A member was added to a security-enabled universal group.\n4757: A member was removed from a security-enabled universal group.\n4758: A security-enabled universal group was deleted.\n4764: A group's type was changed.\nThe recommended state for this setting is: Success and Failure .",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success and Failure :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management\\Audit Security Group Management"
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Security Group Management\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;"
+                    },
+                    "description": "17.2.5 Ensure 'Audit Security Group Management' is set to 'Success and Failure'",
+                    "nodeGroupsOpen": true
+                },
+                {
+                    "id": "10-2-5-Use-of-and-changes-to-identification-and-authentication-mechanisms-including-but-not-limited-to-creation-of-new-accounts-and-elevation-of-privileges-and-all-changes-additions-or-deletions-to-accounts-with-root-or-administrative-privileges17-5-5-L1-Ensure-Audit-Other-Logon-Logoff-Events-is-set-to-Success-and-Failure-",
+                    "name": "17.5.5 (L1) Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "Other Logon/Logoff Events": [
+                            {
+                                "exp": "Success and Failure",
+                                "check": "equals",
+                                "expected": "Success and Failure",
+                                "background": "This subcategory reports other logon/logoff-related events, such as Terminal Services session disconnects and reconnects, using RunAs to run processes under a different account, and locking and unlocking a workstation. Events for this subcategory include:\n4649: A replay attack was detected.\n4778: A session was reconnected to a Window Station.\n4779: A session was disconnected from a Window Station.\n4800: The workstation was locked.\n4801: The workstation was unlocked.\n4802: The screen saver was invoked.\n4803: The screen saver was dismissed.\n5378: The requested credentials delegation was disallowed by policy.\n5632: A request was made to authenticate to a wireless network.\n5633: A request was made to authenticate to a wired network.\nThe recommended state for this setting is: Success and Failure .",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success and Failure\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff\\Audit Other Logon/Logoff Events"
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.5.5 (L1) Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Other Logon/Logoff Events\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;"
+                    },
+                    "description": "17.5.5 (L1) Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and Failure'",
+                    "nodeGroupsOpen": true
+                }
+            ]
+        },
+        {
+            "10.2.6 Initialization, stopping, or pausing of the audit logs": [
+                {
+                    "id": "10-2-6-Initialization-stopping-or-pausing-of-the-audit-logs17-7-1-Ensure-Audit-Audit-Policy-Change-is-set-to-Success-and-Failure-",
+                    "name": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "Policy Change": {
+                            "check": "equals",
+                            "expected": "Success and Failure",
+                            "valueSelectList": null,
+                            "attributeSelectList": [
+                                "User Account Management"
+                            ],
+                            "availableAttributes": [
+                                {
+                                    "User Account Management": "Success"
+                                }
+                            ]
+                        }
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "description": "17.7.1 Ensure 'Audit Audit Policy Change' is set to 'Success and Failure'",
+                    "nodeGroupsOpen": true
+                },
+                {
+                    "id": "10-2-6-Initialization-stopping-or-pausing-of-the-audit-logs17-7-2-Ensure-Audit-Authentication-Policy-Change-is-set-to-Success-",
+                    "name": "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "Authentication Policy Change": [
+                            {
+                                "check": "equals",
+                                "expected": "Success",
+                                "valueSelectList": [
+                                    "Success"
+                                ],
+                                "attributeSelectList": [
+                                    "Authentication Policy Change"
+                                ],
+                                "availableAttributes": [
+                                    {
+                                        "Authentication Policy Change": "Success"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Authentication Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "description": "17.7.2 Ensure 'Audit Authentication Policy Change' is set to 'Success'",
+                    "nodeGroupsOpen": true
+                }
+            ]
+        },
+        {
+            "10.2.7 Creation and deletion of system-level objects": [
+                {
+                    "id": "10-2-7-Creation-and-deletion-of-system-level-objects17-4-1-Ensure-Audit-Directory-Service-Access-is-set-to-Success-and-Failure-",
+                    "name": "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "Directory Service Access": [
+                            {
+                                "exp": "Success",
+                                "check": "equals",
+                                "expected": "Success",
+                                "background": "This subcategory reports when an AD DS object is accessed. Only objects with SACLs cause audit events to be generated, and only when they are accessed in a manner that matches their SACL. These events are similar to the directory service access events in previous versions of Windows Server. This subcategory applies only to domain controllers. Events for this subcategory include:\n4662 : An operation was performed on an object.\nThe recommended state for this setting is: Success and Failure .",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success and Failure :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\DS Access\\Audit Directory Service Access"
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Directory Service Access\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "description": "17.4.1 Ensure 'Audit Directory Service Access' is set to 'Success and Failure'",
+                    "nodeGroupsOpen": true
+                },
+                {
+                    "id": "10-2-7-Creation-and-deletion-of-system-level-objects17-6-1-Ensure-Audit-Removable-Storage-is-set-to-Success-and-Failure-",
+                    "name": "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ],
+                        "Removable Storage": [
+                            {
+                                "exp": "Success And Failure",
+                                "check": "equals",
+                                "expected": "Success And Failure",
+                                "background": "This policy setting allows you to audit user attempts to access file system objects on a removable storage device. A security audit event is generated only for all objects for all types of access requested. If you configure this policy setting, an audit event is generated each time an account accesses a file system object on a removable storage. Success audits record successful attempts and Failure audits record unsuccessful attempts. If you do not configure this policy setting, no audit event is generated when an account accesses a file system object on a removable storage. The recommended state for this setting is: Success and Failure .",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Success and Failure :\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Object Access\\Audit Removable Storage"
+                            }
+                        ]
+                    },
+                    "ci_path": [
+                        "PowerShell",
+                        "Queries",
+                        "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'"
+                    ],
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$APolicySetting=\"Removable Storage\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+                    },
+                    "description": "17.6.1 Ensure 'Audit Removable Storage' is set to 'Success and Failure'",
+                    "nodeGroupsOpen": true
+                }
+            ]
+        }
+    ],
+    "scan_options": {
+        "powershell_queries": [
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Plug and Play\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Process Creation\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Other Account Management Events\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Account Lockout\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Computer Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"User Account Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Group Membership\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Logoff \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Logon \";  $APolicyOutput= (Invoke-Expression \"auditpol /get /subcategory:$APolicySetting\") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Distribution Group Management\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Security Group Management\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Other Logon/Logoff Events\"; $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting; $obj = New-Object psobject; if ($APolicyOutput){ $APolicyOutput -match ' ([a-z, /-]+) ([a-z, ]+)' | Out-Null; $APolicyStatus= $Matches[2]; $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus; } else { $obj | add-member -Type Noteproperty -Name $APolicySetting -Value \"Setting does not exists\";} $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Authentication Policy Change\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Directory Service Access\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            },
+            {
+                "description": null,
+                "query": "$APolicySetting=\"Removable Storage\";  $APolicyOutput= (Invoke-Expression \"auditpol /get /category:* \") | Select-String $APolicySetting;  $obj = New-Object psobject;   if ($APolicyOutput){      $APolicyOutput -match '  ([a-z, /-]+)  ([a-z, ]+)' | Out-Null;     $APolicyStatus= $Matches[2];     $obj | add-member -Type NoteProperty -Name $APolicySetting -Value $APolicyStatus;      }          else { $obj | add-member -Type Noteproperty -Name $APolicySetting  -Value \"Setting does not exists\";}      $obj;"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Windows provides an auditing feature. PCI specifies that this should be enabled but does not give any details. However, Chapters 17.2, 18 and 19 of Server 2016 CIS specification provide a lot of details on how this should be configured
[CIS_Microsoft_Windows_Server_2016_RTM_Release 1607_Benchmark_v1.0.0.pdf](https://github.com/ScriptRock/content/files/1334098/CIS_Microsoft_Windows_Server_2016_RTM_Release.1607_Benchmark_v1.0.0.pdf)
