### PR TITLE
Pci passwords win better registry script

### DIFF
--- a/policies/PCI_3_2_Password_Check_Windows.json
+++ b/policies/PCI_3_2_Password_Check_Windows.json
@@ -135,13 +135,6 @@
                     "name": "[PCI: Password-Check] PCI: Check Session Idle Timeout is 15 minutes or less",
                     "error": false,
                     "checks": {
-                        "Value": [
-                            {
-                                "check": "excludes",
-                                "expected": "missing",
-                                "valueSelectList": null
-                            }
-                        ],
                         "present": [
                             {
                                 "exp": "true",
@@ -149,6 +142,13 @@
                                 "expected": "true",
                                 "background": "This setting helps to prevent active Remote Desktop sessions from tying up the computer for long periods of time while not in use, preventing computing resources from being consumed by large numbers of inactive sessions. In addition, old, forgotten Remote Desktops session that are still active can cause password lockouts if the user's password has changed but the old session is still running. For systems that limit the number of connected users (e.g. servers in the default Administrative mode - 2 sessions only), other users' old but still active sessions can prevent another user from connecting, resulting in an effective denial of service.",
                                 "remediation": "To establish the recommended configuration via GP, set the following UI path to Enabled: 15 minutes or less: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Session Time Limits\\Set time limit for active but idle Remote Desktop Services sessions"
+                            }
+                        ],
+                        "KEY PRESENT": [
+                            {
+                                "check": "equals",
+                                "expected": "YES",
+                                "valueSelectList": null
                             }
                         ],
                         "MaxIdleTime": [
@@ -162,12 +162,19 @@
                                 "check": "conditional",
                                 "valueSelectList": null
                             }
+                        ],
+                        "VALUE PRESENT": [
+                            {
+                                "check": "equals",
+                                "expected": "YES",
+                                "valueSelectList": null
+                            }
                         ]
                     },
                     "ci_path": null,
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "$Value=\"missing\"; Try{ $Value= (Get-ItemProperty -Path 'HKLM:\\\\SOFTWARE\\Policies\\Microsoft\\ Windows NT\\Terminal Services' -Name MaxIdleTime -ErrorAction Stop) | Select -expandproperty MaxIdleTime } Catch { }; $Value;",
+                        "query": "$Key='HKLM:\\\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'; $Value = 'MaxIdleTime'; $KeyPresent=Test-Path $Key;  if ($KeyPresent -eq $False) {    $KeyPresent=\"NO\"; $ValuePresent = \"n/a\";  $KeyValue = \"n/a\" } else { $KeyPresent=\"YES\";    Try{$KeyValue = (Get-ItemProperty -Path $Key -Name $Value -ErrorAction Stop) | Select -ExpandProperty $Value;   $ValuePresent = \"YES\"; }  catch{ $ValuePresent=\"NO\";  $KeyValue=\"n\\a\"; } } $obj = New-Object psobject; $obj | add-member -Type Noteproperty \"KEY PRESENT\" -Value $KeyPresent; $obj | add-member -Type Noteproperty \"VALUE PRESENT\" -Value $ValuePresent; $obj | add-member -Type Noteproperty $Value -Value $KeyValue; $obj;",
                         "description": "[PCI: Password-Check] PCI: Check Session Idle Timeout is 15 minutes or less"
                     },
                     "description": "[PCI: Password-Check] PCI: Check Session Idle Timeout is 15 minutes or less",
@@ -344,10 +351,11 @@
                     "ci_path": null,
                     "check_type": "powershell",
                     "powershell": {
-                        "query": "echo \"20170920-2\";",
+                        "query": "echo \"20170926-0\";",
                         "description": "[PCI: Password-Check] Policy Version"
                     },
-                    "description": "[PCI: Password-Check] Policy Version"
+                    "description": "[PCI: Password-Check] Policy Version",
+                    "nodeGroupsOpen": true
                 }
             ]
         }
@@ -368,7 +376,7 @@
             },
             {
                 "description": "[PCI: Password-Check] PCI: Check Session Idle Timeout is 15 minutes or less",
-                "query": "$Value=\"missing\"; Try{ $Value= (Get-ItemProperty -Path 'HKLM:\\\\SOFTWARE\\Policies\\Microsoft\\ Windows NT\\Terminal Services' -Name MaxIdleTime -ErrorAction Stop) | Select -expandproperty MaxIdleTime } Catch { }; $Value;"
+                "query": "$Key='HKLM:\\\\SOFTWARE\\Policies\\Microsoft\\Windows NT\\Terminal Services'; $Value = 'MaxIdleTime'; $KeyPresent=Test-Path $Key;  if ($KeyPresent -eq $False) {    $KeyPresent=\"NO\"; $ValuePresent = \"n/a\";  $KeyValue = \"n/a\" } else { $KeyPresent=\"YES\";    Try{$KeyValue = (Get-ItemProperty -Path $Key -Name $Value -ErrorAction Stop) | Select -ExpandProperty $Value;   $ValuePresent = \"YES\"; }  catch{ $ValuePresent=\"NO\";  $KeyValue=\"n\\a\"; } } $obj = New-Object psobject; $obj | add-member -Type Noteproperty \"KEY PRESENT\" -Value $KeyPresent; $obj | add-member -Type Noteproperty \"VALUE PRESENT\" -Value $ValuePresent; $obj | add-member -Type Noteproperty $Value -Value $KeyValue; $obj;"
             },
             {
                 "description": "[PCI: Password-Check] Use secedit.exe command to obtain PasswordComplexity value",
@@ -388,7 +396,7 @@
             },
             {
                 "description": "[PCI: Password-Check] Policy Version",
-                "query": "echo \"20170920-2\";"
+                "query": "echo \"20170926-0\";"
             }
         ]
     }

--- a/policies/PCI_3_2_Password_Check_Windows.json
+++ b/policies/PCI_3_2_Password_Check_Windows.json
@@ -1,1 +1,395 @@
-{"policy":{"name":"pci_32_password_check_--_windows","short_description":"PCI 3.2 Password Check -- Windows","description":null,"settings":{"tests":{"output_format":null}},"operating_system_family_id":null,"operating_system_id":null,"type":null},"data":[{"8.1.4 Find And Remove/Disable Inactive User Accounts Within 90 Days.":[{"id":"8-1-4-Find-And-Remove-Disable-Inactive-User-Accounts-Within-90-Days-PCI-Password-Check-Use-ADSI-to-find-last-login-date-should-have-the-defined-properties","name":"[PCI: Password-Check] Use ADSI to find last login date should have the defined properties","error":false,"checks":{"present":[{"exp":"true","check":"equals","expected":"true","background":"Inactive user accounts pose a risk to systems and applications. Owners of Inactive accounts will not notice if unauthorized access to their account has been obtained. There is a risk that inactive accounts can potentially be exploited to obtain and maintain undetected access to a system and/or application. The operating system must track periods of user account inactivity and disable all inactive accounts. Non-interactive accounts on the system, such as application accounts, may be documented exceptions. Non-interactive accounts on the system, such as application accounts, may be documented exceptions. Non-interactive accounts on the system, such as application accounts, may be documented exceptions.","remediation":"Investigate inactive accounts and take appropriate action."}],"InActiveAccounts":[{"check":"equals","expected":"0","valueSelectList":null}]},"ci_path":null,"check_type":"powershell","powershell":{"query":"$Accnts = @() ; $StartDate=get-date; ([ADSI]\"WinNT://$env:computername\").children| Where{$_.class -eq 'User'}| ForEach{ $Accnt= New-Object PSObject -Property @{Name=$_.Name[0];LastLogin=($_.lastlogin[0]);};$Accnts += $Accnt;}; $Count= ((($Accnts -match \"/\" ) | where {$_.LastLogin -lt (Get-Date).AddDays(-90)}) | Measure).Count; $obj = New-Object psobject; $obj | add-member -Type Noteproperty \"InActiveAccounts\" -Value $Count; $obj;","description":"[PCI: Password-Check] Use ADSI to find last login date should have the defined properties"},"description":"[PCI: Password-Check] Use ADSI to find last login date should have the defined properties","nodeGroupsOpen":true}]},{"8.1.6 Limit Repeated Access Attempts By Locking Out The User ID After Not More Than Six Attempts.":[{"id":"8-1-6-Limit-Repeated-Access-Attempts-By-Locking-Out-The-User-ID-After-Not-More-Than-Six-Attempts-PCI-Password-Check-Parse-Lockout-threshold-from-net-accounts-command","name":"[PCI: Password-Check] Parse Lockout threshold from net accounts command","error":false,"checks":{"Value":[{"cond":[{"op":"<=","val":"6"}],"check":"conditional","valueSelectList":null}],"present":[{"exp":"true","check":"equals","expected":"true","background":"Setting an account lockout threshold reduces the likelihood that an online password brute force attack will be successful. Setting the account lockout threshold too low introduces risk of increased accidental lockouts and/or a malicious actor intentionally locking out accounts.","remediation":"To establish the recommended configuration via GP, set the following UI path to 10 or fewer invalid login attempt(s), but not 0: \n\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Account Policies\\Account Lockout Policy\\Account lockout threshold"}]},"ci_path":null,"check_type":"powershell","powershell":{"query":"$v=((net accounts | select-string \"Lockout duration\") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object","description":"[PCI: Password-Check] Parse Lockout threshold from net accounts command"},"description":"[PCI: Password-Check] Parse Lockout threshold from net accounts command","nodeGroupsOpen":true}]},{"8.1.7 Set The Lockout Duration To A Minimum Of 30 Minutes Or Until An Administrator Enables The User ID.":[{"id":"8-1-7-Set-The-Lockout-Duration-To-A-Minimum-Of-30-Minutes-Or-Until-An-Administrator-Enables-The-User-ID-PCI-Password-Check-Parse-Lockout-duration-from-net-accounts-command","name":"[PCI: Password-Check] Parse Lockout duration from net accounts command","error":false,"checks":{"Value":[{"cond":[{"op":">=","val":"30"}],"check":"conditional","valueSelectList":null}],"present":[{"exp":"true","check":"equals","expected":"true","background":"A denial of service (DoS) condition can be created if an attacker abuses the Account lockout threshold and repeatedly attempts to log on with a specific account. Once you configure the Account lockout threshold setting, the account will be locked out after the specified number of failed attempts. If you configure the Account lockout duration setting to 0, then the account will remain locked out until an administrator unlocks it manually.","remediation":"To establish the recommended configuration via GP, set the following UI path to 15 or more minute(s): Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Account Policies\\Account Lockout Policy\\Account lockout duration"}]},"ci_path":null,"check_type":"powershell","powershell":{"query":"$v=((net accounts | select-string \"Lockout threshold\") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object","description":"[PCI: Password-Check] Parse Lockout duration from net accounts command"},"description":"[PCI: Password-Check] Parse Lockout duration from net accounts command","nodeGroupsOpen":true}]},{"8.1.8 If A Session Has Been Idle For More Than 15 Minutes, Require The User To Re-Authenticate To Re-Activate The Terminal Or Session.":[{"id":"8-1-8-If-A-Session-Has-Been-Idle-For-More-Than-15-Minutes-Require-The-User-To-Re-Authenticate-To-Re-Activate-The-Terminal-Or-Session-PCI-Password-Check-PCI-Check-Session-Idle-Timeout-is-15-minutes-or-less","name":"[PCI: Password-Check] PCI: Check Session Idle Timeout is 15 minutes or less","error":false,"checks":{"Value":[{"check":"excludes","expected":"missing","valueSelectList":null}],"present":[{"exp":"true","check":"equals","expected":"true","background":"This setting helps to prevent active Remote Desktop sessions from tying up the computer for long periods of time while not in use, preventing computing resources from being consumed by large numbers of inactive sessions. In addition, old, forgotten Remote Desktops session that are still active can cause password lockouts if the user's password has changed but the old session is still running. For systems that limit the number of connected users (e.g. servers in the default Administrative mode - 2 sessions only), other users' old but still active sessions can prevent another user from connecting, resulting in an effective denial of service.","remediation":"To establish the recommended configuration via GP, set the following UI path to Enabled: 15 minutes or less: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Session Time Limits\\Set time limit for active but idle Remote Desktop Services sessions"}],"MaxIdleTime":[{"cond":[{"op":"<=","val":"56250"}],"check":"conditional","valueSelectList":null}]},"ci_path":null,"check_type":"powershell","powershell":{"query":"$Value=\"missing\"; Try{ $Value= (Get-ItemProperty -Path 'HKLM:\\\\SOFTWARE\\Policies\\Microsoft\\ Windows NT\\Terminal Services' -Name MaxIdleTime -ErrorAction Stop) | Select -expandproperty MaxIdleTime } Catch { }; $Value;","description":"[PCI: Password-Check] PCI: Check Session Idle Timeout is 15 minutes or less"},"description":"[PCI: Password-Check] PCI: Check Session Idle Timeout is 15 minutes or less","nodeGroupsOpen":true}]},{"8.2.3 Passwords/Passphrases Must Meet Strong Requirements":[{"id":"8-2-3-Passwords-Passphrases-Must-Meet-Strong-Requirements-PCI-Password-Check-Use-secedit-exe-command-to-obtain-PasswordComplexity-value","name":"[PCI: Password-Check] Use secedit.exe command to obtain PasswordComplexity value","error":false,"checks":{"present":[{"exp":"true","check":"equals","expected":"true","background":"The use of complex passwords increases their strength against attack. The built-in Windows password complexity policy requires passwords to contain at least 3 of the 4 types of characters (numbers, upper- and lower-case letters, and special characters), as well as preventing the inclusion of user names or parts of.","remediation":"Configure the policy value for Computer Configuration -> Windows Settings >> Security Settings >> Account Policies >> Password Policy >> \"Password must meet complexity requirements\" to \"Enabled\"."}],"PasswordComplexity":[{"check":"equals","expected":"1","valueSelectList":null}]},"ci_path":null,"check_type":"powershell","powershell":{"query":"function New-TemporaryDirectory { $parent = [System.IO.Path]::GetTempPath(); [string] $name = [System.Guid]::NewGuid(); New-Item -ItemType Directory -Path (Join-Path $parent $name); }  $FileName= New-TemporaryDirectory; $FileName = \"$FileName\\PwdInfo\"+ (Get-date -format ddMMyyhh) + \".txt\"; Invoke-Expression \"C:\\windows\\system32\\secedit.exe /export /cfg $FileName /quiet\" ; $arr=@((cat $FileName |Select-string \"PasswordComplexity\" ) -split \"=\").trim(); $obj = New-Object psobject ; $obj | add-member -Type Noteproperty \"PasswordComplexity\" -Value $arr[1] ; $obj; Remove-Item $FileName","description":"[PCI: Password-Check] Use secedit.exe command to obtain PasswordComplexity value"},"description":"[PCI: Password-Check] Use secedit.exe command to obtain PasswordComplexity value","nodeGroupsOpen":true},{"id":"8-2-3-Passwords-Passphrases-Must-Meet-Strong-Requirements-PCI-Password-Check-Parse-Minimum-Password-Length-from-net-accounts-command","name":"[PCI: Password-Check] Parse Minimum Password Length from net accounts command","error":false,"checks":{"Value":[{"cond":[{"op":">=","val":"7"}],"check":"conditional","valueSelectList":null}],"present":[{"exp":"true","check":"equals","expected":"true","background":"Information systems not protected with strong password schemes (including passwords of minimum length) provide the opportunity for anyone to crack the password, thus gaining access to the system and compromising the device, information, or the local network.","remediation":"Configure the policy value for Computer Configuration -> Windows Settings -> Security Settings -> Account Policies -> Password Policy -> \"Minimum password length\" to at least \"7\" characters."}]},"ci_path":null,"check_type":"powershell","powershell":{"query":"$v=((net accounts | select-string \"Minimum Password Length\") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object","description":"[PCI: Password-Check] Parse Minimum Password Length from net accounts command"},"description":"[PCI: Password-Check] Parse Minimum Password Length from net accounts command","nodeGroupsOpen":true}]},{"8.2.4 Change User Passwords/Passphrases At Least Once Every 90 Days.":[{"id":"8-2-4-Change-User-Passwords-Passphrases-At-Least-Once-Every-90-Days-PCI-Password-Check-Parse-Maximum-Password-age-from-net-accounts-command","name":"[PCI: Password-Check] Parse Maximum Password age from net accounts command","error":false,"checks":{"Value":[{"exp":"90","cond":[{"op":"<=","val":"90"}],"check":"conditional","expected":"90"}],"present":[{"exp":"true","check":"equals","expected":"true","background":"The longer a password exists the higher the likelihood that it will be compromised by a brute force attack, by an attacker gaining general knowledge about the user, or by the user sharing the password. Configuring the Maximum password age setting to 0 so that users are never required to change their passwords is a major security risk because that allows a compromised password to be used by the malicious user for as long as the valid user is authorized access.","remediation":"To establish the recommended configuration via GP, set the following UI path to 90 or fewer days, but not 0: Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Account Policies\\Password Policy\\Maximum password age"}]},"ci_path":null,"check_type":"powershell","powershell":{"query":"$v=((net accounts | select-string \"Maximum Password age \") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object","description":"[PCI: Password-Check] Parse Maximum Password age from net accounts command"},"description":"[PCI: Password-Check] Parse Maximum Password age from net accounts command","nodeGroupsOpen":true}]},{"8.2.5 Do Not Allow An Individual To Submit A New Password/Passphrase That Is The Same As Any Of The Last Four Passwords/Passphrases He Or She Has Used.":[{"id":"8-2-5-Do-Not-Allow-An-Individual-To-Submit-A-New-Password-Passphrase-That-Is-The-Same-As-Any-Of-The-Last-Four-Passwords-Passphrases-He-Or-She-Has-Used-PCI-Password-Check-Use-secedit-exe-command-to-obtain-PasswordHistorySize-value","name":"[PCI: Password-Check] Use secedit.exe command to obtain PasswordHistorySize value","error":false,"checks":{"present":[{"exp":"true","check":"equals","expected":"true","background":"The longer a user uses the same password, the greater the chance that an attacker can determine the password through brute force attacks. Also, any accounts that may have been compromised will remain exploitable for as long as the password is left unchanged. If password changes are required but password reuse is not prevented, or if users continually reuse a small number of passwords, the effectiveness of a good password policy is greatly reduced.\nIf you specify a low number for this policy setting, users will be able to use the same small number of passwords repeatedly. If you do not also configure the Minimum password age setting, users might repeatedly change their passwords until they can reuse their original password.","remediation":"To establish the recommended configuration via GP, set the following UI path to 24 or more password(s): \n\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Account Policies\\Password Policy\\Enforce password history"}],"PasswordHistorySize":[{"cond":[{"op":"<=","val":"4"}],"check":"conditional","valueSelectList":null}]},"ci_path":null,"check_type":"powershell","powershell":{"query":"function New-TemporaryDirectory { $parent = [System.IO.Path]::GetTempPath(); [string] $name = [System.Guid]::NewGuid(); New-Item -ItemType Directory -Path (Join-Path $parent $name); } $FileName=New-TemporaryDirectory; $FileName =  \"$FileName\\HistoryInfo\"+ (Get-date -format ddMMyyhh) + \".txt\"; Invoke-Expression \"C:\\windows\\system32\\secedit.exe /export /cfg $FileName /quiet\" ; $arr=@((cat $FileName |Select-string \"PasswordHistorySize\" ) -split \"=\").trim() ;$obj = New-Object psobject ;$obj | add-member -Type Noteproperty \"PasswordHistorySize\" -Value $arr[1] ;$obj; Remove-Item $FileName","description":"[PCI: Password-Check] Use secedit.exe command to obtain PasswordHistorySize value"},"description":"[PCI: Password-Check] Use secedit.exe command to obtain PasswordHistorySize value","nodeGroupsOpen":true}]},{"Version":[{"id":"Version-PCI-Password-Check-Policy-Version","name":"[PCI: Password-Check] Policy Version","error":false,"checks":{"present":[{"check":"equals","expected":"true"}]},"ci_path":null,"check_type":"powershell","powershell":{"query":"echo \"20170920-2\";","description":"[PCI: Password-Check] Policy Version"},"description":"[PCI: Password-Check] Policy Version"}]}],"scan_options":{"powershell_queries":[{"description":"[PCI: Password-Check] Use ADSI to find last login date should have the defined properties","query":"$Accnts = @() ; $StartDate=get-date; ([ADSI]\"WinNT://$env:computername\").children| Where{$_.class -eq 'User'}| ForEach{ $Accnt= New-Object PSObject -Property @{Name=$_.Name[0];LastLogin=($_.lastlogin[0]);};$Accnts += $Accnt;}; $Count= ((($Accnts -match \"/\" ) | where {$_.LastLogin -lt (Get-Date).AddDays(-90)}) | Measure).Count; $obj = New-Object psobject; $obj | add-member -Type Noteproperty \"InActiveAccounts\" -Value $Count; $obj;"},{"description":"[PCI: Password-Check] Parse Lockout threshold from net accounts command","query":"$v=((net accounts | select-string \"Lockout duration\") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object"},{"description":"[PCI: Password-Check] Parse Lockout duration from net accounts command","query":"$v=((net accounts | select-string \"Lockout threshold\") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object"},{"description":"[PCI: Password-Check] PCI: Check Session Idle Timeout is 15 minutes or less","query":"$Value=\"missing\"; Try{ $Value= (Get-ItemProperty -Path 'HKLM:\\\\SOFTWARE\\Policies\\Microsoft\\ Windows NT\\Terminal Services' -Name MaxIdleTime -ErrorAction Stop) | Select -expandproperty MaxIdleTime } Catch { }; $Value;"},{"description":"[PCI: Password-Check] Use secedit.exe command to obtain PasswordComplexity value","query":"function New-TemporaryDirectory { $parent = [System.IO.Path]::GetTempPath(); [string] $name = [System.Guid]::NewGuid(); New-Item -ItemType Directory -Path (Join-Path $parent $name); }  $FileName= New-TemporaryDirectory; $FileName = \"$FileName\\PwdInfo\"+ (Get-date -format ddMMyyhh) + \".txt\"; Invoke-Expression \"C:\\windows\\system32\\secedit.exe /export /cfg $FileName /quiet\" ; $arr=@((cat $FileName |Select-string \"PasswordComplexity\" ) -split \"=\").trim(); $obj = New-Object psobject ; $obj | add-member -Type Noteproperty \"PasswordComplexity\" -Value $arr[1] ; $obj; Remove-Item $FileName"},{"description":"[PCI: Password-Check] Parse Minimum Password Length from net accounts command","query":"$v=((net accounts | select-string \"Minimum Password Length\") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object"},{"description":"[PCI: Password-Check] Parse Maximum Password age from net accounts command","query":"$v=((net accounts | select-string \"Maximum Password age \") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object"},{"description":"[PCI: Password-Check] Use secedit.exe command to obtain PasswordHistorySize value","query":"function New-TemporaryDirectory { $parent = [System.IO.Path]::GetTempPath(); [string] $name = [System.Guid]::NewGuid(); New-Item -ItemType Directory -Path (Join-Path $parent $name); } $FileName=New-TemporaryDirectory; $FileName =  \"$FileName\\HistoryInfo\"+ (Get-date -format ddMMyyhh) + \".txt\"; Invoke-Expression \"C:\\windows\\system32\\secedit.exe /export /cfg $FileName /quiet\" ; $arr=@((cat $FileName |Select-string \"PasswordHistorySize\" ) -split \"=\").trim() ;$obj = New-Object psobject ;$obj | add-member -Type Noteproperty \"PasswordHistorySize\" -Value $arr[1] ;$obj; Remove-Item $FileName"},{"description":"[PCI: Password-Check] Policy Version","query":"echo \"20170920-2\";"}]}}
+{
+    "policy": {
+        "name": "pci_32_password_check_--_windows",
+        "short_description": "PCI 3.2 Password Check -- Windows",
+        "description": null,
+        "settings": {
+            "tests": {
+                "output_format": null
+            }
+        },
+        "operating_system_family_id": null,
+        "operating_system_id": null,
+        "type": null
+    },
+    "data": [
+        {
+            "8.1.4 Find And Remove/Disable Inactive User Accounts Within 90 Days.": [
+                {
+                    "id": "8-1-4-Find-And-Remove-Disable-Inactive-User-Accounts-Within-90-Days-PCI-Password-Check-Use-ADSI-to-find-last-login-date-should-have-the-defined-properties",
+                    "name": "[PCI: Password-Check] Use ADSI to find last login date should have the defined properties",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "exp": "true",
+                                "check": "equals",
+                                "expected": "true",
+                                "background": "Inactive user accounts pose a risk to systems and applications. Owners of Inactive accounts will not notice if unauthorized access to their account has been obtained. There is a risk that inactive accounts can potentially be exploited to obtain and maintain undetected access to a system and/or application. The operating system must track periods of user account inactivity and disable all inactive accounts. Non-interactive accounts on the system, such as application accounts, may be documented exceptions. Non-interactive accounts on the system, such as application accounts, may be documented exceptions. Non-interactive accounts on the system, such as application accounts, may be documented exceptions.",
+                                "remediation": "Investigate inactive accounts and take appropriate action."
+                            }
+                        ],
+                        "InActiveAccounts": [
+                            {
+                                "check": "equals",
+                                "expected": "0",
+                                "valueSelectList": null
+                            }
+                        ]
+                    },
+                    "ci_path": null,
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$Accnts = @() ; $StartDate=get-date; ([ADSI]\"WinNT://$env:computername\").children| Where{$_.class -eq 'User'}| ForEach{ $Accnt= New-Object PSObject -Property @{Name=$_.Name[0];LastLogin=($_.lastlogin[0]);};$Accnts += $Accnt;}; $Count= ((($Accnts -match \"/\" ) | where {$_.LastLogin -lt (Get-Date).AddDays(-90)}) | Measure).Count; $obj = New-Object psobject; $obj | add-member -Type Noteproperty \"InActiveAccounts\" -Value $Count; $obj;",
+                        "description": "[PCI: Password-Check] Use ADSI to find last login date should have the defined properties"
+                    },
+                    "description": "[PCI: Password-Check] Use ADSI to find last login date should have the defined properties",
+                    "nodeGroupsOpen": true
+                }
+            ]
+        },
+        {
+            "8.1.6 Limit Repeated Access Attempts By Locking Out The User ID After Not More Than Six Attempts.": [
+                {
+                    "id": "8-1-6-Limit-Repeated-Access-Attempts-By-Locking-Out-The-User-ID-After-Not-More-Than-Six-Attempts-PCI-Password-Check-Parse-Lockout-threshold-from-net-accounts-command",
+                    "name": "[PCI: Password-Check] Parse Lockout threshold from net accounts command",
+                    "error": false,
+                    "checks": {
+                        "Value": [
+                            {
+                                "cond": [
+                                    {
+                                        "op": "<=",
+                                        "val": "6"
+                                    }
+                                ],
+                                "check": "conditional",
+                                "valueSelectList": null
+                            }
+                        ],
+                        "present": [
+                            {
+                                "exp": "true",
+                                "check": "equals",
+                                "expected": "true",
+                                "background": "Setting an account lockout threshold reduces the likelihood that an online password brute force attack will be successful. Setting the account lockout threshold too low introduces risk of increased accidental lockouts and/or a malicious actor intentionally locking out accounts.",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to 10 or fewer invalid login attempt(s), but not 0: \n\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Account Policies\\Account Lockout Policy\\Account lockout threshold"
+                            }
+                        ]
+                    },
+                    "ci_path": null,
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$v=((net accounts | select-string \"Lockout duration\") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object",
+                        "description": "[PCI: Password-Check] Parse Lockout threshold from net accounts command"
+                    },
+                    "description": "[PCI: Password-Check] Parse Lockout threshold from net accounts command",
+                    "nodeGroupsOpen": true
+                }
+            ]
+        },
+        {
+            "8.1.7 Set The Lockout Duration To A Minimum Of 30 Minutes Or Until An Administrator Enables The User ID.": [
+                {
+                    "id": "8-1-7-Set-The-Lockout-Duration-To-A-Minimum-Of-30-Minutes-Or-Until-An-Administrator-Enables-The-User-ID-PCI-Password-Check-Parse-Lockout-duration-from-net-accounts-command",
+                    "name": "[PCI: Password-Check] Parse Lockout duration from net accounts command",
+                    "error": false,
+                    "checks": {
+                        "Value": [
+                            {
+                                "cond": [
+                                    {
+                                        "op": ">=",
+                                        "val": "30"
+                                    }
+                                ],
+                                "check": "conditional",
+                                "valueSelectList": null
+                            }
+                        ],
+                        "present": [
+                            {
+                                "exp": "true",
+                                "check": "equals",
+                                "expected": "true",
+                                "background": "A denial of service (DoS) condition can be created if an attacker abuses the Account lockout threshold and repeatedly attempts to log on with a specific account. Once you configure the Account lockout threshold setting, the account will be locked out after the specified number of failed attempts. If you configure the Account lockout duration setting to 0, then the account will remain locked out until an administrator unlocks it manually.",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to 15 or more minute(s): Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Account Policies\\Account Lockout Policy\\Account lockout duration"
+                            }
+                        ]
+                    },
+                    "ci_path": null,
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$v=((net accounts | select-string \"Lockout threshold\") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object",
+                        "description": "[PCI: Password-Check] Parse Lockout duration from net accounts command"
+                    },
+                    "description": "[PCI: Password-Check] Parse Lockout duration from net accounts command",
+                    "nodeGroupsOpen": true
+                }
+            ]
+        },
+        {
+            "8.1.8 If A Session Has Been Idle For More Than 15 Minutes, Require The User To Re-Authenticate To Re-Activate The Terminal Or Session.": [
+                {
+                    "id": "8-1-8-If-A-Session-Has-Been-Idle-For-More-Than-15-Minutes-Require-The-User-To-Re-Authenticate-To-Re-Activate-The-Terminal-Or-Session-PCI-Password-Check-PCI-Check-Session-Idle-Timeout-is-15-minutes-or-less",
+                    "name": "[PCI: Password-Check] PCI: Check Session Idle Timeout is 15 minutes or less",
+                    "error": false,
+                    "checks": {
+                        "Value": [
+                            {
+                                "check": "excludes",
+                                "expected": "missing",
+                                "valueSelectList": null
+                            }
+                        ],
+                        "present": [
+                            {
+                                "exp": "true",
+                                "check": "equals",
+                                "expected": "true",
+                                "background": "This setting helps to prevent active Remote Desktop sessions from tying up the computer for long periods of time while not in use, preventing computing resources from being consumed by large numbers of inactive sessions. In addition, old, forgotten Remote Desktops session that are still active can cause password lockouts if the user's password has changed but the old session is still running. For systems that limit the number of connected users (e.g. servers in the default Administrative mode - 2 sessions only), other users' old but still active sessions can prevent another user from connecting, resulting in an effective denial of service.",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to Enabled: 15 minutes or less: Computer Configuration\\Policies\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Session Time Limits\\Set time limit for active but idle Remote Desktop Services sessions"
+                            }
+                        ],
+                        "MaxIdleTime": [
+                            {
+                                "cond": [
+                                    {
+                                        "op": "<=",
+                                        "val": "56250"
+                                    }
+                                ],
+                                "check": "conditional",
+                                "valueSelectList": null
+                            }
+                        ]
+                    },
+                    "ci_path": null,
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$Value=\"missing\"; Try{ $Value= (Get-ItemProperty -Path 'HKLM:\\\\SOFTWARE\\Policies\\Microsoft\\ Windows NT\\Terminal Services' -Name MaxIdleTime -ErrorAction Stop) | Select -expandproperty MaxIdleTime } Catch { }; $Value;",
+                        "description": "[PCI: Password-Check] PCI: Check Session Idle Timeout is 15 minutes or less"
+                    },
+                    "description": "[PCI: Password-Check] PCI: Check Session Idle Timeout is 15 minutes or less",
+                    "nodeGroupsOpen": true
+                }
+            ]
+        },
+        {
+            "8.2.3 Passwords/Passphrases Must Meet Strong Requirements": [
+                {
+                    "id": "8-2-3-Passwords-Passphrases-Must-Meet-Strong-Requirements-PCI-Password-Check-Use-secedit-exe-command-to-obtain-PasswordComplexity-value",
+                    "name": "[PCI: Password-Check] Use secedit.exe command to obtain PasswordComplexity value",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "exp": "true",
+                                "check": "equals",
+                                "expected": "true",
+                                "background": "The use of complex passwords increases their strength against attack. The built-in Windows password complexity policy requires passwords to contain at least 3 of the 4 types of characters (numbers, upper- and lower-case letters, and special characters), as well as preventing the inclusion of user names or parts of.",
+                                "remediation": "Configure the policy value for Computer Configuration -> Windows Settings >> Security Settings >> Account Policies >> Password Policy >> \"Password must meet complexity requirements\" to \"Enabled\"."
+                            }
+                        ],
+                        "PasswordComplexity": [
+                            {
+                                "check": "equals",
+                                "expected": "1",
+                                "valueSelectList": null
+                            }
+                        ]
+                    },
+                    "ci_path": null,
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "function New-TemporaryDirectory { $parent = [System.IO.Path]::GetTempPath(); [string] $name = [System.Guid]::NewGuid(); New-Item -ItemType Directory -Path (Join-Path $parent $name); }  $FileName= New-TemporaryDirectory; $FileName = \"$FileName\\PwdInfo\"+ (Get-date -format ddMMyyhh) + \".txt\"; Invoke-Expression \"C:\\windows\\system32\\secedit.exe /export /cfg $FileName /quiet\" ; $arr=@((cat $FileName |Select-string \"PasswordComplexity\" ) -split \"=\").trim(); $obj = New-Object psobject ; $obj | add-member -Type Noteproperty \"PasswordComplexity\" -Value $arr[1] ; $obj; Remove-Item $FileName",
+                        "description": "[PCI: Password-Check] Use secedit.exe command to obtain PasswordComplexity value"
+                    },
+                    "description": "[PCI: Password-Check] Use secedit.exe command to obtain PasswordComplexity value",
+                    "nodeGroupsOpen": true
+                },
+                {
+                    "id": "8-2-3-Passwords-Passphrases-Must-Meet-Strong-Requirements-PCI-Password-Check-Parse-Minimum-Password-Length-from-net-accounts-command",
+                    "name": "[PCI: Password-Check] Parse Minimum Password Length from net accounts command",
+                    "error": false,
+                    "checks": {
+                        "Value": [
+                            {
+                                "cond": [
+                                    {
+                                        "op": ">=",
+                                        "val": "7"
+                                    }
+                                ],
+                                "check": "conditional",
+                                "valueSelectList": null
+                            }
+                        ],
+                        "present": [
+                            {
+                                "exp": "true",
+                                "check": "equals",
+                                "expected": "true",
+                                "background": "Information systems not protected with strong password schemes (including passwords of minimum length) provide the opportunity for anyone to crack the password, thus gaining access to the system and compromising the device, information, or the local network.",
+                                "remediation": "Configure the policy value for Computer Configuration -> Windows Settings -> Security Settings -> Account Policies -> Password Policy -> \"Minimum password length\" to at least \"7\" characters."
+                            }
+                        ]
+                    },
+                    "ci_path": null,
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$v=((net accounts | select-string \"Minimum Password Length\") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object",
+                        "description": "[PCI: Password-Check] Parse Minimum Password Length from net accounts command"
+                    },
+                    "description": "[PCI: Password-Check] Parse Minimum Password Length from net accounts command",
+                    "nodeGroupsOpen": true
+                }
+            ]
+        },
+        {
+            "8.2.4 Change User Passwords/Passphrases At Least Once Every 90 Days.": [
+                {
+                    "id": "8-2-4-Change-User-Passwords-Passphrases-At-Least-Once-Every-90-Days-PCI-Password-Check-Parse-Maximum-Password-age-from-net-accounts-command",
+                    "name": "[PCI: Password-Check] Parse Maximum Password age from net accounts command",
+                    "error": false,
+                    "checks": {
+                        "Value": [
+                            {
+                                "exp": "90",
+                                "cond": [
+                                    {
+                                        "op": "<=",
+                                        "val": "90"
+                                    }
+                                ],
+                                "check": "conditional",
+                                "expected": "90"
+                            }
+                        ],
+                        "present": [
+                            {
+                                "exp": "true",
+                                "check": "equals",
+                                "expected": "true",
+                                "background": "The longer a password exists the higher the likelihood that it will be compromised by a brute force attack, by an attacker gaining general knowledge about the user, or by the user sharing the password. Configuring the Maximum password age setting to 0 so that users are never required to change their passwords is a major security risk because that allows a compromised password to be used by the malicious user for as long as the valid user is authorized access.",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to 90 or fewer days, but not 0: Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Account Policies\\Password Policy\\Maximum password age"
+                            }
+                        ]
+                    },
+                    "ci_path": null,
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "$v=((net accounts | select-string \"Maximum Password age \") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object",
+                        "description": "[PCI: Password-Check] Parse Maximum Password age from net accounts command"
+                    },
+                    "description": "[PCI: Password-Check] Parse Maximum Password age from net accounts command",
+                    "nodeGroupsOpen": true
+                }
+            ]
+        },
+        {
+            "8.2.5 Do Not Allow An Individual To Submit A New Password/Passphrase That Is The Same As Any Of The Last Four Passwords/Passphrases He Or She Has Used.": [
+                {
+                    "id": "8-2-5-Do-Not-Allow-An-Individual-To-Submit-A-New-Password-Passphrase-That-Is-The-Same-As-Any-Of-The-Last-Four-Passwords-Passphrases-He-Or-She-Has-Used-PCI-Password-Check-Use-secedit-exe-command-to-obtain-PasswordHistorySize-value",
+                    "name": "[PCI: Password-Check] Use secedit.exe command to obtain PasswordHistorySize value",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "exp": "true",
+                                "check": "equals",
+                                "expected": "true",
+                                "background": "The longer a user uses the same password, the greater the chance that an attacker can determine the password through brute force attacks. Also, any accounts that may have been compromised will remain exploitable for as long as the password is left unchanged. If password changes are required but password reuse is not prevented, or if users continually reuse a small number of passwords, the effectiveness of a good password policy is greatly reduced.\nIf you specify a low number for this policy setting, users will be able to use the same small number of passwords repeatedly. If you do not also configure the Minimum password age setting, users might repeatedly change their passwords until they can reuse their original password.",
+                                "remediation": "To establish the recommended configuration via GP, set the following UI path to 24 or more password(s): \n\nComputer Configuration\\Policies\\Windows Settings\\Security Settings\\Account Policies\\Password Policy\\Enforce password history"
+                            }
+                        ],
+                        "PasswordHistorySize": [
+                            {
+                                "cond": [
+                                    {
+                                        "op": "<=",
+                                        "val": "4"
+                                    }
+                                ],
+                                "check": "conditional",
+                                "valueSelectList": null
+                            }
+                        ]
+                    },
+                    "ci_path": null,
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "function New-TemporaryDirectory { $parent = [System.IO.Path]::GetTempPath(); [string] $name = [System.Guid]::NewGuid(); New-Item -ItemType Directory -Path (Join-Path $parent $name); } $FileName=New-TemporaryDirectory; $FileName =  \"$FileName\\HistoryInfo\"+ (Get-date -format ddMMyyhh) + \".txt\"; Invoke-Expression \"C:\\windows\\system32\\secedit.exe /export /cfg $FileName /quiet\" ; $arr=@((cat $FileName |Select-string \"PasswordHistorySize\" ) -split \"=\").trim() ;$obj = New-Object psobject ;$obj | add-member -Type Noteproperty \"PasswordHistorySize\" -Value $arr[1] ;$obj; Remove-Item $FileName",
+                        "description": "[PCI: Password-Check] Use secedit.exe command to obtain PasswordHistorySize value"
+                    },
+                    "description": "[PCI: Password-Check] Use secedit.exe command to obtain PasswordHistorySize value",
+                    "nodeGroupsOpen": true
+                }
+            ]
+        },
+        {
+            "Version": [
+                {
+                    "id": "Version-PCI-Password-Check-Policy-Version",
+                    "name": "[PCI: Password-Check] Policy Version",
+                    "error": false,
+                    "checks": {
+                        "present": [
+                            {
+                                "check": "equals",
+                                "expected": "true"
+                            }
+                        ]
+                    },
+                    "ci_path": null,
+                    "check_type": "powershell",
+                    "powershell": {
+                        "query": "echo \"20170920-2\";",
+                        "description": "[PCI: Password-Check] Policy Version"
+                    },
+                    "description": "[PCI: Password-Check] Policy Version"
+                }
+            ]
+        }
+    ],
+    "scan_options": {
+        "powershell_queries": [
+            {
+                "description": "[PCI: Password-Check] Use ADSI to find last login date should have the defined properties",
+                "query": "$Accnts = @() ; $StartDate=get-date; ([ADSI]\"WinNT://$env:computername\").children| Where{$_.class -eq 'User'}| ForEach{ $Accnt= New-Object PSObject -Property @{Name=$_.Name[0];LastLogin=($_.lastlogin[0]);};$Accnts += $Accnt;}; $Count= ((($Accnts -match \"/\" ) | where {$_.LastLogin -lt (Get-Date).AddDays(-90)}) | Measure).Count; $obj = New-Object psobject; $obj | add-member -Type Noteproperty \"InActiveAccounts\" -Value $Count; $obj;"
+            },
+            {
+                "description": "[PCI: Password-Check] Parse Lockout threshold from net accounts command",
+                "query": "$v=((net accounts | select-string \"Lockout duration\") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object"
+            },
+            {
+                "description": "[PCI: Password-Check] Parse Lockout duration from net accounts command",
+                "query": "$v=((net accounts | select-string \"Lockout threshold\") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object"
+            },
+            {
+                "description": "[PCI: Password-Check] PCI: Check Session Idle Timeout is 15 minutes or less",
+                "query": "$Value=\"missing\"; Try{ $Value= (Get-ItemProperty -Path 'HKLM:\\\\SOFTWARE\\Policies\\Microsoft\\ Windows NT\\Terminal Services' -Name MaxIdleTime -ErrorAction Stop) | Select -expandproperty MaxIdleTime } Catch { }; $Value;"
+            },
+            {
+                "description": "[PCI: Password-Check] Use secedit.exe command to obtain PasswordComplexity value",
+                "query": "function New-TemporaryDirectory { $parent = [System.IO.Path]::GetTempPath(); [string] $name = [System.Guid]::NewGuid(); New-Item -ItemType Directory -Path (Join-Path $parent $name); }  $FileName= New-TemporaryDirectory; $FileName = \"$FileName\\PwdInfo\"+ (Get-date -format ddMMyyhh) + \".txt\"; Invoke-Expression \"C:\\windows\\system32\\secedit.exe /export /cfg $FileName /quiet\" ; $arr=@((cat $FileName |Select-string \"PasswordComplexity\" ) -split \"=\").trim(); $obj = New-Object psobject ; $obj | add-member -Type Noteproperty \"PasswordComplexity\" -Value $arr[1] ; $obj; Remove-Item $FileName"
+            },
+            {
+                "description": "[PCI: Password-Check] Parse Minimum Password Length from net accounts command",
+                "query": "$v=((net accounts | select-string \"Minimum Password Length\") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object"
+            },
+            {
+                "description": "[PCI: Password-Check] Parse Maximum Password age from net accounts command",
+                "query": "$v=((net accounts | select-string \"Maximum Password age \") -split \":\")[1].trim(); $Object = New-Object PSObject; $Object | add-member Noteproperty Value $v; $object"
+            },
+            {
+                "description": "[PCI: Password-Check] Use secedit.exe command to obtain PasswordHistorySize value",
+                "query": "function New-TemporaryDirectory { $parent = [System.IO.Path]::GetTempPath(); [string] $name = [System.Guid]::NewGuid(); New-Item -ItemType Directory -Path (Join-Path $parent $name); } $FileName=New-TemporaryDirectory; $FileName =  \"$FileName\\HistoryInfo\"+ (Get-date -format ddMMyyhh) + \".txt\"; Invoke-Expression \"C:\\windows\\system32\\secedit.exe /export /cfg $FileName /quiet\" ; $arr=@((cat $FileName |Select-string \"PasswordHistorySize\" ) -split \"=\").trim() ;$obj = New-Object psobject ;$obj | add-member -Type Noteproperty \"PasswordHistorySize\" -Value $arr[1] ;$obj; Remove-Item $FileName"
+            },
+            {
+                "description": "[PCI: Password-Check] Policy Version",
+                "query": "echo \"20170920-2\";"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
I found that the registry script did not handle gracefully the case where the registry value was missing. The easiest way to see the diff is by looking here:

https://github.com/ScriptRock/content/commit/433527c7279688e508401c0b976be60932a42a37