### PR TITLE
Create sles_11.4_meltdown_spectre_kernel_version_check

### DIFF
--- a/policies/sles_11.4_meltdown_spectre_kernel_version_check
+++ b/policies/sles_11.4_meltdown_spectre_kernel_version_check
@@ -18,7 +18,8 @@
         {
           "yum": [
             {
-              "name": "kernel-default",
+              "id": "packagesyumThe-kernel-package-should-be-upgraded-above-versions-affected-by-Meltdown-",
+              "name": "The kernel package should be upgraded above versions affected by Meltdown.",
               "checks": {
                 "version": [
                   {
@@ -43,7 +44,41 @@
               "packages": {
                 "name": "kernel-default"
               },
-              "check_type": "packages"
+              "check_type": "packages",
+              "description": "The kernel package should be upgraded above versions affected by Meltdown.",
+              "nodeGroupsOpen": true
+            },
+            {
+              "id": "packagesyumThe-package-microcode-ctl-should-be-installed-",
+              "name": "The microcode_ctl package should be upgraded above versions affected by Meltdown.",
+              "error": false,
+              "checks": {
+                "version": [
+                  {
+                    "check": "version_comparison",
+                    "background": "https://www.suse.com/support/kb/doc/?id=7022512",
+                    "absent_pass": true,
+                    "remediation": "Upgrade microcode_ctl."
+                  }
+                ]
+              },
+              "ci_path": [
+                "packages",
+                "yum",
+                "microcode_ctl"
+              ],
+              "packages": {
+                "name": "microcode_ctl",
+                "provider": "*"
+              },
+              "check_type": "packages",
+              "selectList": [
+                "{\"status\":\"installed\",\"version\":\"2.1-22.el7\"}",
+                "{\"status\":\"installed\",\"version\":\"2.1-16.3.el7_3\"}",
+                "*"
+              ],
+              "description": "The microcode_ctl package should be upgraded above versions affected by Meltdown.",
+              "nodeGroupsOpen": true
             }
           ]
         }

--- a/policies/sles_11.4_meltdown_spectre_kernel_version_check
+++ b/policies/sles_11.4_meltdown_spectre_kernel_version_check
@@ -1,0 +1,54 @@
+{
+  "policy": {
+    "name": "suse_11_sp4_meltdown_kernel_check",
+    "short_description": "SUSE 11 SP4 Meltdown Kernel Check",
+    "description": "",
+    "settings": {
+      "tests": {
+        "output_format": null
+      }
+    },
+    "operating_system_family_id": null,
+    "operating_system_id": null,
+    "type": null
+  },
+  "data": [
+    {
+      "packages": [
+        {
+          "yum": [
+            {
+              "name": "kernel-default",
+              "checks": {
+                "version": [
+                  {
+                    "cond": [
+                      {
+                        "op": ">=",
+                        "val": "3.0.101-108.21.1"
+                      }
+                    ],
+                    "check": "version_comparison",
+                    "expected": "3.0.101-108.21.1",
+                    "background": "See SUSE advisory for Meltdown and Spectre: https://www.suse.com/support/kb/doc/?id=7022512",
+                    "remediation": "Update kernel to latest version."
+                  }
+                ]
+              },
+              "ci_path": [
+                "packages",
+                "yum",
+                "kernel-default"
+              ],
+              "packages": {
+                "name": "kernel-default"
+              },
+              "check_type": "packages"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "scan_options": {}
+}


### PR DESCRIPTION
Same as other meltdown tests, >= the version on the advisory https://www.suse.com/support/kb/doc/?id=7022512. 

I did not include a test for microcode_ctl-1.17-102.83.6.1, which is also in the kb for SUSE 11.4. I don't see that on our scan; not sure if we should add it as a "pass if absent" check.