### PR TITLE
Add policy to check for BlueKeep (CVE-2019-0708)

### DIFF
--- a/policies/bluekeep-cve-check-policy.json
+++ b/policies/bluekeep-cve-check-policy.json
@@ -1,0 +1,60 @@
+{
+    "policy": {
+        "name": "bluekeep_cve_check",
+        "short_description": "BlueKeep (CVE-2019-0708) check",
+        "description": null,
+        "settings": {
+            "tests": {
+                "output_format": null
+            }
+        },
+        "operating_system_family_id": null,
+        "operating_system_id": null,
+        "type": null
+    },
+    "data": [
+        {
+            "BlueKeep (CVE-2019-0708)": [
+                {
+                    "Queries": [
+                        {
+                            "id": "BlueKeep-CVE-2019-0708-QueriesThe-output-of-the-BlueKeep-vulnerability-check-query-should-show-that-the-target-system-is-not-vulnerable-",
+                            "name": "The output of the BlueKeep vulnerability check query should show that the target system is not vulnerable.",
+                            "checks": {
+                                "vulnerable": [
+                                    {
+                                        "exp": "No",
+                                        "check": "equals",
+                                        "expected": "No"
+                                    }
+                                ]
+                            },
+                            "ci_path": [
+                                "PowerShell",
+                                "Queries",
+                                "BlueKeep (CVE-2019-0708) Vuln Test"
+                            ],
+                            "check_type": "powershell",
+                            "powershell": {
+                                "query": "# UpGuard BlueKeep (CVE-2019-0708) check\n# Look for minimum safe versions of termdd.sys\n# Zakk Acreman <zakk.acreman@upguard.com>\n# 2019-05-28\n\n$output = \"\" | Select vulnerable, reason, minSafeVersion, foundVersion, detectedOs\n\ntry {\n    $os = Get-WmiObject -class Win32_OperatingSystem\n    $output.detectedOs = $os.Caption\n} catch {\n    $output.vulnerable = \"Unknown\"\n    $output.reason = \"Unable to get Win32_OperatingSystem\"\n    $output.minSafeVersion = \"n/a\"\n    $output.foundVersion = \"n/a\"\n    $output.detectedOS = \"Unknown\"\n\n    return $output\n}\n\nif ($os.Caption.Contains(\"Windows 8\") -or $os.Caption.Contains(\"Windows 10\") -or $os.Caption.Contains(\"2012\") -or $os.Caption.Contains(\"2016\")) {\n        $output.vulnerable = \"No\"\n        $output.reason = \"Operating system version is not vulnerable to BlueKeep (CVE-2019-0708).\"\n        $output.minSafeVersion = \"n/a\"\n        $output.foundVersion = \"n/a\"\n\n        return $output\n}\n\n\nif ($os.Caption.Contains(\"Windows XP\")) {\n    $output.minSafeVersion = New-Object System.Version(\"5.1.2600.7701\")\n} elseif ($os.Caption.Contains(\"Server 2003\")) {\n    $output.minSafeVersion = New-Object System.Version(\"5.2.3790.6787\")\n} elseif ($os.Caption.Contains(\"Windows 7\") -or $os.Caption.Contains(\"2008 R2\")) {\n    $output.minSafeVersion = New-Object System.Version(\"6.1.7601.24441\")\n} elseif ($os.Caption.Contains(\"2008\") -and -not $os.Caption.Contains(\"R2\")) {\n    $output.minSafeVersion = New-Object System.Version(\"6.0.6003.20514\")\n} elseif ($os.Caption.Contains(\"Vista\")) {\n    $output.minSafeVersion = New-Object System.Version(\"6.0.6003.20514\")\n} else {\n    $output.vulnerable = \"Unknown\"\n    $output.reason = $os.Caption + \"didn't match any operating system selection criteria. Check for CVE-2019-0708 by hand.\"\n    $output.minSafeVersion = \"n/a\"\n    $output.foundVersion = \"n/a\"\n\n    return $output\n}\n\ntry {\n    $fileLocation = $os.SystemDirectory + \"\\drivers\\termdd.sys\"\n    $versionInfo = (Get-Item $fileLocation).VersionInfo\n} catch {\n        $output.vulnerable = \"Unknown\"\n        $output.reason = \"Failed to pull version information for termdd.sys\"\n        $output.minSafeVersion = \"n/a\"\n        $output.foundVersion = \"n/a\"\n\n        return $output\n}\n\n$output.foundVersion = New-Object System.Version($versionInfo.ProductVersion)\n\nif ($($output.foundVersion.CompareTo($output.minSafeVersion)) -lt 0) {\n    $output.vulnerable = \"Yes\"\n    $output.reason = \"Found version is less than minimum safe version.\"\n} else {\n    $output.vulnerable = \"No\"\n    $output.reason = \"Found version is greater than or equal to minimum safe version.\"\n}\n\n$output",
+                                "key_name": "",
+                                "key_value": null,
+                                "description": "BlueKeep (CVE-2019-0708) Vuln Test"
+                            },
+                            "description": "The output of the BlueKeep vulnerability check query should show that the target system is not vulnerable.",
+                            "nodeGroupsOpen": true
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "scan_options": {
+        "powershell_queries": [
+            {
+                "description": "BlueKeep (CVE-2019-0708) Vuln Test",
+                "query": "# UpGuard BlueKeep (CVE-2019-0708) check\n# Look for minimum safe versions of termdd.sys\n# Zakk Acreman <zakk.acreman@upguard.com>\n# 2019-05-28\n\n$output = \"\" | Select vulnerable, reason, minSafeVersion, foundVersion, detectedOs\n\ntry {\n    $os = Get-WmiObject -class Win32_OperatingSystem\n    $output.detectedOs = $os.Caption\n} catch {\n    $output.vulnerable = \"Unknown\"\n    $output.reason = \"Unable to get Win32_OperatingSystem\"\n    $output.minSafeVersion = \"n/a\"\n    $output.foundVersion = \"n/a\"\n    $output.detectedOS = \"Unknown\"\n\n    return $output\n}\n\nif ($os.Caption.Contains(\"Windows 8\") -or $os.Caption.Contains(\"Windows 10\") -or $os.Caption.Contains(\"2012\") -or $os.Caption.Contains(\"2016\")) {\n        $output.vulnerable = \"No\"\n        $output.reason = \"Operating system version is not vulnerable to BlueKeep (CVE-2019-0708).\"\n        $output.minSafeVersion = \"n/a\"\n        $output.foundVersion = \"n/a\"\n\n        return $output\n}\n\n\nif ($os.Caption.Contains(\"Windows XP\")) {\n    $output.minSafeVersion = New-Object System.Version(\"5.1.2600.7701\")\n} elseif ($os.Caption.Contains(\"Server 2003\")) {\n    $output.minSafeVersion = New-Object System.Version(\"5.2.3790.6787\")\n} elseif ($os.Caption.Contains(\"Windows 7\") -or $os.Caption.Contains(\"2008 R2\")) {\n    $output.minSafeVersion = New-Object System.Version(\"6.1.7601.24441\")\n} elseif ($os.Caption.Contains(\"2008\") -and -not $os.Caption.Contains(\"R2\")) {\n    $output.minSafeVersion = New-Object System.Version(\"6.0.6003.20514\")\n} elseif ($os.Caption.Contains(\"Vista\")) {\n    $output.minSafeVersion = New-Object System.Version(\"6.0.6003.20514\")\n} else {\n    $output.vulnerable = \"Unknown\"\n    $output.reason = $os.Caption + \"didn't match any operating system selection criteria. Check for CVE-2019-0708 by hand.\"\n    $output.minSafeVersion = \"n/a\"\n    $output.foundVersion = \"n/a\"\n\n    return $output\n}\n\ntry {\n    $fileLocation = $os.SystemDirectory + \"\\drivers\\termdd.sys\"\n    $versionInfo = (Get-Item $fileLocation).VersionInfo\n} catch {\n        $output.vulnerable = \"Unknown\"\n        $output.reason = \"Failed to pull version information for termdd.sys\"\n        $output.minSafeVersion = \"n/a\"\n        $output.foundVersion = \"n/a\"\n\n        return $output\n}\n\n$output.foundVersion = New-Object System.Version($versionInfo.ProductVersion)\n\nif ($($output.foundVersion.CompareTo($output.minSafeVersion)) -lt 0) {\n    $output.vulnerable = \"Yes\"\n    $output.reason = \"Found version is less than minimum safe version.\"\n} else {\n    $output.vulnerable = \"No\"\n    $output.reason = \"Found version is greater than or equal to minimum safe version.\"\n}\n\n$output"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Checks the version on termdd.sys and compares to the versions provided in the hotfixes for relevant Windows versions.

Sample results on Test:
https://test.upguard.org/reports/policies#/2211?checkTypes=passing&checkTypes=failing&dateFrom=Tue%2C%2028%20May%202019%2021%3A47%3A13%20GMT&dateTo=2019-05-28T18%3A03%3A13-04%3A00